### PR TITLE
Compound db object

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
@@ -66,6 +66,14 @@ class CompoundDESCQAObject(DESCQAObject):
         super(CompoundDESCQAObject, self).__init__()
 
     def _make_column_map(self):
+        """
+        This dummy method is needed because the call to
+        super(CompoundDESCQAObject, self).__init__() in
+        this class's __init__ will try to call
+        self._make_column_map().  We have already done
+        the column map construciton in self.__init__()
+        and thus, do not want to do anything more.
+        """
         pass
 
     def _validate_input(self):

--- a/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
@@ -8,53 +8,39 @@ __all__ = ["CompoundDESCQAObject"]
 
 class CompoundDESCQAObject(DESCQAObject):
     """
-    This is a class for taking several CatalogDBObject daughter classes that
-    query the same table of the same database for the same rows (but different
-    columns; note that the columns can be transformed by the CatalogDBObjects'
-    self.columns member), and combining their queries into one.
+    This is a class for taking several DESCQAObject daughter classes that
+    query the same catalog for the same rows (but different
+    columns), and combining their queries into one.
 
-    You feed the constructor a list of CatalogDBObject daughter classes.  The
-    CompoundCatalogDBObject verifies that they all do, indeed, query the same table
-    of the same database.  It then constructs its own self.columns member (note
-    that CompoundCatalogDBObject is a daughter class of CatalogDBObject) which
+    You feed the constructor a list of DESCQAObject daughter classes.  The
+    CompoundDESCQAObject verifies that they all do, indeed, query the same
+    catalog.  It then constructs its own self.columns member (note
+    that CompoundDESCQAObject is a daughter class of DESQAObject) which
     combines all of the requested data.
 
-    When you call query_columns, a recarray will be returned as in a CatalogDBObject.
+    When you call query_columns, a recarray will be returned as in a DESCQAObject.
     Note, however, that the names of the columns of the recarray will be modified.
-    If the first CatalogDBObject in the list of CatalogDBObjects passed to the constructor
-    asks for a column named 'col1', that will be mapped to 'catName_col1' where 'catName'
-    is the CatalogDBObject's objid member.  'col2' will be mapped to 'catName_col2', etc.
-    In cases where the CatalogDBObject does not change the name of the column, the column
-    will also be returned by its original, un-mangled name.
-
-    In cases where a custom query_columns method must be implemented, this class
-    can be sub-classed and the custom method added as a member method.  In that
-    case, the _table_restriction member variable should be set to a list of table
-    names corresponding to the tables for which this class was designed.  An
-    exception will be raised if the user tries to use the CompoundCatalogDBObject
-    class to query tables for which it was not written.  _table_restriction defaults
-    to None, which means that the class is for use with any table.
+    If the first DESCQAObject class in the list of DESCQAObject classes passed to the
+    constructor asks for a column named 'col1', that will be mapped to 'catName_col1'
+    where 'catName' is the DESCQAObject's objid member.  'col2' will be mapped to
+    'catName_col2', etc.  In cases where the DESCQAObject does not change the name
+    of the column, the column will also be returned by its original, un-mangled name.
     """
 
     def __init__(self, catalogDbObjectClassList, connection=None):
         """
-        @param [in] catalogDbObjectClassList is a list of CatalogDBObject
+        @param [in] descqaObjectClassList is a list of DESCQAObject
         daughter classes (not instantiations of those classes; the classes
-        themselves) that all query the same database table
+        themselves) that all query the same catalog
 
         Note: this is a list of classes, not a list of instantiations of those
-        classes.  The connection to the database is established as soon as
-        you instantiate a CatalogDBObject daughter class.  To avoid creating
-        unnecessary database connections, CompoundCatalogDBObject will
+        classes.  The connection to the catalog is established as soon as
+        you instantiate a DESCQAObject daughter class.  To avoid creating
+        unnecessary connections, CompoundDESCQAObject will
         read in classes without an active connection and establish its
         own connection in this constructor.  This means that all connection
         parameters must be specified in the class definitions of the classes
-        passed into catalogDbObjectClassList.
-
-        @param [in] connection is an optional instantiation of DBConnection
-        representing an active connection to the database required by
-        this CompoundCatalogDBObject (prevents the CompoundCatalogDBObject
-        from opening a redundant connection)
+        passed into descqaObjectClassList.
         """
 
         self._dbObjectClassList = catalogDbObjectClassList
@@ -84,8 +70,8 @@ class CompoundDESCQAObject(DESCQAObject):
 
     def _validate_input(self):
         """
-        Verify that the CatalogDBObjects passed to the constructor
-        do, indeed, query the same table of the same database.
+        Verify that the DESCQAObjects passed to the constructor
+        do, indeed, query the same table of the same catalog.
         """
 
         dbc0 = self._dbObjectClassList[0]

--- a/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
@@ -27,7 +27,7 @@ class CompoundDESCQAObject(DESCQAObject):
     of the column, the column will also be returned by its original, un-mangled name.
     """
 
-    def __init__(self, descqaObjectClassList):
+    def __init__(self, catalogDbObjectClassList, connection=None):
         """
         @param [in] descqaObjectClassList is a list of DESCQAObject
         daughter classes (not instantiations of those classes; the classes
@@ -43,18 +43,18 @@ class CompoundDESCQAObject(DESCQAObject):
         passed into descqaObjectClassList.
         """
 
-        self._descqaObjectClassList = descqaObjectClassList
+        self._dbObjectClassList = catalogDbObjectClassList
         self._validate_input()
         self.objectTypeId = 119
 
         self.columnMap = dict()
-        for dbc in self._descqaObjectClassList:
+        for dbc in self._dbObjectClassList:
             sub_cat_name = dbc.objid
             dbo = dbc()
             for col_name in dbo.columnMap:
                 self.columnMap[sub_cat_name+'_'+col_name] = dbo.columnMap[col_name]
 
-        dbo = self._descqaObjectClassList[0]()
+        dbo = self._dbObjectClassList[0]()
         # need to instantiate the first one because sometimes
         # idColKey is not defined until instantiation
         # (see GalaxyTileObj in sims_catUtils/../baseCatalogModels/GalaxyModels.py)
@@ -82,8 +82,8 @@ class CompoundDESCQAObject(DESCQAObject):
         do, indeed, query the same table of the same catalog.
         """
 
-        dbc0 = self._descqaObjectClassList[0]
-        for dbc in self._descqaObjectClassList:
+        dbc0 = self._dbObjectClassList[0]
+        for dbc in self._dbObjectClassList:
             if (dbc.yaml_file_name != dbc0.yaml_file_name or
                 dbc._cat_cache_suffix != dbc0._cat_cache_suffix):
 

--- a/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
@@ -4,6 +4,12 @@ __all__ = ["CompoundDESCQACatalogDBObject"]
 
 class CompoundDESCQACatalogDBObject(CompoundCatalogDBObject):
 
+    def _make_dbTypeMap(self):
+        pass
+
+    def _make_dbDefaultValues(self):
+        pass
+
     def _validate_input(self):
         """
         Verify that CatalogDBObject classes passed to the constructor

--- a/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
@@ -45,7 +45,10 @@ class CompoundDESCQAObject(DESCQAObject):
 
         self._dbObjectClassList = catalogDbObjectClassList
         self._validate_input()
-        self.objectTypeId = 119
+        self.objectTypeId = -1  # this is just a placeholder;
+                                # the objectTypeId for the classes in
+                                # self._dbObjectClassList will actually
+                                # be used at runtime
 
         self.columnMap = dict()
         for dbc in self._dbObjectClassList:

--- a/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
@@ -1,26 +1,98 @@
-from lsst.sims.catalogs.db import CompoundCatalogDBObject
+from builtins import zip
+from builtins import str
+from builtins import range
+from desc.sims.GCRCatSimInterface import DESCQAObject
 
-__all__ = ["CompoundDESCQACatalogDBObject"]
+__all__ = ["CompoundDESCQAObject"]
 
-class CompoundDESCQACatalogDBObject(CompoundCatalogDBObject):
+
+class CompoundDESCQAObject(DESCQAObject):
+    """
+    This is a class for taking several CatalogDBObject daughter classes that
+    query the same table of the same database for the same rows (but different
+    columns; note that the columns can be transformed by the CatalogDBObjects'
+    self.columns member), and combining their queries into one.
+
+    You feed the constructor a list of CatalogDBObject daughter classes.  The
+    CompoundCatalogDBObject verifies that they all do, indeed, query the same table
+    of the same database.  It then constructs its own self.columns member (note
+    that CompoundCatalogDBObject is a daughter class of CatalogDBObject) which
+    combines all of the requested data.
+
+    When you call query_columns, a recarray will be returned as in a CatalogDBObject.
+    Note, however, that the names of the columns of the recarray will be modified.
+    If the first CatalogDBObject in the list of CatalogDBObjects passed to the constructor
+    asks for a column named 'col1', that will be mapped to 'catName_col1' where 'catName'
+    is the CatalogDBObject's objid member.  'col2' will be mapped to 'catName_col2', etc.
+    In cases where the CatalogDBObject does not change the name of the column, the column
+    will also be returned by its original, un-mangled name.
+
+    In cases where a custom query_columns method must be implemented, this class
+    can be sub-classed and the custom method added as a member method.  In that
+    case, the _table_restriction member variable should be set to a list of table
+    names corresponding to the tables for which this class was designed.  An
+    exception will be raised if the user tries to use the CompoundCatalogDBObject
+    class to query tables for which it was not written.  _table_restriction defaults
+    to None, which means that the class is for use with any table.
+    """
+
+    def __init__(self, catalogDbObjectClassList, connection=None):
+        """
+        @param [in] catalogDbObjectClassList is a list of CatalogDBObject
+        daughter classes (not instantiations of those classes; the classes
+        themselves) that all query the same database table
+
+        Note: this is a list of classes, not a list of instantiations of those
+        classes.  The connection to the database is established as soon as
+        you instantiate a CatalogDBObject daughter class.  To avoid creating
+        unnecessary database connections, CompoundCatalogDBObject will
+        read in classes without an active connection and establish its
+        own connection in this constructor.  This means that all connection
+        parameters must be specified in the class definitions of the classes
+        passed into catalogDbObjectClassList.
+
+        @param [in] connection is an optional instantiation of DBConnection
+        representing an active connection to the database required by
+        this CompoundCatalogDBObject (prevents the CompoundCatalogDBObject
+        from opening a redundant connection)
+        """
+
+        self._dbObjectClassList = catalogDbObjectClassList
+        self._validate_input()
+        self.objectTypeId = 119
+
+        self.columnMap = dict()
+        for dbc in self._dbObjectClassList:
+            sub_cat_name = dbc.objid
+            dbo = dbc()
+            for col_name in dbo.columnMap:
+                self.columnMap[sub_cat_name+'_'+col_name] = dbo.columnMap[col_name]
+
+        dbo = self._dbObjectClassList[0]()
+        # need to instantiate the first one because sometimes
+        # idColKey is not defined until instantiation
+        # (see GalaxyTileObj in sims_catUtils/../baseCatalogModels/GalaxyModels.py)
+
+        self.idColKey = dbo.idColKey
+        self.yaml_file_name = dbo.yaml_file_name
+        self._cat_cache_suffix = dbo._cat_cache_suffix
+
+        super(CompoundDESCQAObject, self).__init__()
+
+    def _make_column_map(self):
+        pass
 
     def _validate_input(self):
         """
-        Verify that CatalogDBObject classes passed to the constructor
-        do, indeed, all query the same catalog.
+        Verify that the CatalogDBObjects passed to the constructor
+        do, indeed, query the same table of the same database.
         """
 
         dbc0 = self._dbObjectClassList[0]
-
-        acceptable = True
-
         for dbc in self._dbObjectClassList:
-            if dbc.yaml_file_name != dbc0.yaml_file_name:
-                acceptable = False
-            if dbc._cat_cache_suffix != dbc0._cat_cache_suffix:
-                acceptable = False
+            if (dbc.yaml_file_name != dbc0.yaml_file_name or
+                dbc._cat_cache_suffix != dbc0._cat_cache_suffix):
 
-        if not acceptable:
-            raise RuntimeError("The CatalogDBObject classes passed to "
-                               "CompoundDESCQACatalogDBObject do not all "
-                               "query the same catalog")
+                raise RuntimeError("Not all DESCQAObject classes "
+                                   "passed to CompoundDESCQAObject "
+                                   "reference the same catalog")

--- a/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
@@ -4,12 +4,6 @@ __all__ = ["CompoundDESCQACatalogDBObject"]
 
 class CompoundDESCQACatalogDBObject(CompoundCatalogDBObject):
 
-    def _make_dbTypeMap(self):
-        pass
-
-    def _make_dbDefaultValues(self):
-        pass
-
     def _validate_input(self):
         """
         Verify that CatalogDBObject classes passed to the constructor

--- a/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
@@ -27,7 +27,7 @@ class CompoundDESCQAObject(DESCQAObject):
     of the column, the column will also be returned by its original, un-mangled name.
     """
 
-    def __init__(self, catalogDbObjectClassList, connection=None):
+    def __init__(self, descqaObjectClassList):
         """
         @param [in] descqaObjectClassList is a list of DESCQAObject
         daughter classes (not instantiations of those classes; the classes
@@ -43,18 +43,18 @@ class CompoundDESCQAObject(DESCQAObject):
         passed into descqaObjectClassList.
         """
 
-        self._dbObjectClassList = catalogDbObjectClassList
+        self._descqaObjectClassList = descqaObjectClassList
         self._validate_input()
         self.objectTypeId = 119
 
         self.columnMap = dict()
-        for dbc in self._dbObjectClassList:
+        for dbc in self._descqaObjectClassList:
             sub_cat_name = dbc.objid
             dbo = dbc()
             for col_name in dbo.columnMap:
                 self.columnMap[sub_cat_name+'_'+col_name] = dbo.columnMap[col_name]
 
-        dbo = self._dbObjectClassList[0]()
+        dbo = self._descqaObjectClassList[0]()
         # need to instantiate the first one because sometimes
         # idColKey is not defined until instantiation
         # (see GalaxyTileObj in sims_catUtils/../baseCatalogModels/GalaxyModels.py)
@@ -74,8 +74,8 @@ class CompoundDESCQAObject(DESCQAObject):
         do, indeed, query the same table of the same catalog.
         """
 
-        dbc0 = self._dbObjectClassList[0]
-        for dbc in self._dbObjectClassList:
+        dbc0 = self._descqaObjectClassList[0]
+        for dbc in self._descqaObjectClassList:
             if (dbc.yaml_file_name != dbc0.yaml_file_name or
                 dbc._cat_cache_suffix != dbc0._cat_cache_suffix):
 

--- a/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundCatalogDBObjectClasses.py
@@ -1,0 +1,26 @@
+from lsst.sims.catalogs.db import CompoundCatalogDBObject
+
+__all__ = ["CompoundDESCQACatalogDBObject"]
+
+class CompoundDESCQACatalogDBObject(CompoundCatalogDBObject):
+
+    def _validate_input(self):
+        """
+        Verify that CatalogDBObject classes passed to the constructor
+        do, indeed, all query the same catalog.
+        """
+
+        dbc0 = self._dbObjectClassList[0]
+
+        acceptable = True
+
+        for dbc in self._dbObjectClassList:
+            if dbc.yaml_file_name != dbc0.yaml_file_name:
+                acceptable = False
+            if dbc._cat_cache_suffix != dbc0._cat_cache_suffix:
+                acceptable = False
+
+        if not acceptable:
+            raise RuntimeError("The CatalogDBObject classes passed to "
+                               "CompoundDESCQACatalogDBObject do not all "
+                               "query the same catalog")

--- a/python/desc/sims/GCRCatSimInterface/CompoundInstanceCatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundInstanceCatalogClasses.py
@@ -1,0 +1,18 @@
+from lsst.sims.catalogs.definitions import CompoundInstanceCatalog
+
+class CompoundDESCQAInstanceCatalog(CompoundInstanceCatalog):
+
+    def areDBObjectsTheSame(self, db1, db2):
+        """
+        Parameters
+        ----------
+        db1 and db2 are two instantiations of DESCQA CatalogDBObjects.
+
+        Returns
+        -------
+        True if db1._catalog_id == db2._catalog_id
+
+        False otherwise
+        """
+        return (db1.yaml_file_name == db2.yaml_file_name and
+                db1._cat_cache_suffix == db2._cat_cache_suffix)

--- a/python/desc/sims/GCRCatSimInterface/CompoundInstanceCatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CompoundInstanceCatalogClasses.py
@@ -1,5 +1,7 @@
 from lsst.sims.catalogs.definitions import CompoundInstanceCatalog
 
+__all__ = ["CompoundDESCQAInstanceCatalog"]
+
 class CompoundDESCQAInstanceCatalog(CompoundInstanceCatalog):
 
     def areDBObjectsTheSame(self, db1, db2):

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -158,6 +158,7 @@ class DESCQAObject(object):
             _CATALOG_CACHE[yaml_file_name + self._cat_cache_suffix] = gc
 
         self._catalog = _CATALOG_CACHE[yaml_file_name + self._cat_cache_suffix]
+        self._catalog_id = yaml_file_name + self._cat_cache_suffix
         self.columnMap = None
         self._make_column_map()
 

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -224,15 +224,18 @@ class DESCQAObject(object):
         used to get it into units expected by CatSim.
         """
         self.columnMap = dict()
+        self.columns = []
 
         for name in self._catalog.list_all_quantities(include_native=True):
             self.columnMap[name] = (name,)
+            self.columns.append((name, name))
 
         if self._columns_need_postfix:
             if not self._postfix:
                 raise ValueError('must specify `_postfix` when `_columns_need_postfix` is not empty')
             for name in self._columns_need_postfix:
                 self.columnMap[name] = (name + self._postfix,)
+                self.columns.append((name, name+self._postfix))
 
 
     def query_columns(self, colnames=None, chunk_size=None,

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -140,8 +140,7 @@ class DESCQAObject(object):
                                      # self._transform_catalog()
                                      # methods can be loaded simultaneously
 
-    def __init__(self, yaml_file_name=None, config_overwrite=None,
-                 connection=None):
+    def __init__(self, yaml_file_name=None, config_overwrite=None):
         """
         Parameters
         ----------

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -140,13 +140,20 @@ class DESCQAObject(object):
                                      # self._transform_catalog()
                                      # methods can be loaded simultaneously
 
-    def __init__(self, yaml_file_name, config_overwrite=None):
+    def __init__(self, yaml_file_name=None, config_overwrite=None):
         """
         Parameters
         ----------
         yaml_file_name is the name of the yaml file that will tell DESCQA
         how to load the catalog
         """
+
+        if yaml_file_name is None:
+            if not hasattr(self, 'yaml_file_name'):
+                raise RuntimeError('No yaml_file_name specified for '
+                                   'DESCQAObject')
+
+            yaml_file_name = self.yaml_file_name
 
         if not _GCR_IS_AVAILABLE:
             raise RuntimeError("You cannot use DESCQAObject\n"

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -166,7 +166,6 @@ class DESCQAObject(object):
 
         self._catalog = _CATALOG_CACHE[yaml_file_name + self._cat_cache_suffix]
         self._catalog_id = yaml_file_name + self._cat_cache_suffix
-        self.columnMap = None
         self._make_column_map()
 
         if self.objectTypeId is None:

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -140,7 +140,8 @@ class DESCQAObject(object):
                                      # self._transform_catalog()
                                      # methods can be loaded simultaneously
 
-    def __init__(self, yaml_file_name=None, config_overwrite=None):
+    def __init__(self, yaml_file_name=None, config_overwrite=None,
+                 connection=None):
         """
         Parameters
         ----------

--- a/python/desc/sims/GCRCatSimInterface/__init__.py
+++ b/python/desc/sims/GCRCatSimInterface/__init__.py
@@ -4,3 +4,4 @@ from .DatabaseEmulator import *
 from .ProtoDC2DatabaseEmulator import *
 from .InstanceCatalogWriter import *
 from .SedFitter import *
+from .CompoundInstanceCatalogClasses import *

--- a/python/desc/sims/GCRCatSimInterface/__init__.py
+++ b/python/desc/sims/GCRCatSimInterface/__init__.py
@@ -4,4 +4,5 @@ from .DatabaseEmulator import *
 from .ProtoDC2DatabaseEmulator import *
 from .InstanceCatalogWriter import *
 from .SedFitter import *
+from .CompoundCatalogDBObjectClasses import *
 from .CompoundInstanceCatalogClasses import *

--- a/ups/sims_GCRCatSimInterface.table
+++ b/ups/sims_GCRCatSimInterface.table
@@ -1,4 +1,5 @@
 setupRequired(sims_utils)
+setupRequired(sims_catalogs)
 setupRequired(sims_catUtils)
 
 envPrepend(PATH, ${PRODUCT_DIR}/bin)

--- a/workspace/compound_db/make_compound_catalog.py
+++ b/workspace/compound_db/make_compound_catalog.py
@@ -8,10 +8,6 @@ from lsst.sims.utils import ObservationMetaData
 
 class _testDESCQAObj(object):
     yaml_file_name = 'proto-dc2_v2.1.2'
-    tableid = 'protodc2'
-    raColName = 'ra_true'
-    decColName = 'dec_true'
-    connection = None
 
 class bulgeDESCQAObject_test(_testDESCQAObj, bulgeDESCQAObject):
     objid = 'bulge_descqa'

--- a/workspace/compound_db/make_compound_catalog.py
+++ b/workspace/compound_db/make_compound_catalog.py
@@ -19,19 +19,28 @@ class diskDESCQAObject_test(_testDESCQAObj, diskDESCQAObject_protoDC2):
     objid = 'disk_descqa'
 
 class CatForBulge(InstanceCatalog):
-    column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
+    column_outputs = ['uniqueId', 'objid', 'galaxy_id', 'raJ2000', 'decJ2000',
                       'minorAxis', 'majorAxis']
     transformations = {'minorAxis': arcsecFromRadians,
                        'majorAxis': arcsecFromRadians,
                        'raJ2000': np.degrees,
                        'decJ2000': np.degrees}
 
+    def get_objid(self):
+        return np.array([self.db_obj.objectTypeId]*len(self.column_by_name('raJ2000')))
+
 class CatForDisk(InstanceCatalog):
-    column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
+    column_outputs = ['uniqueId', 'objid', 'galaxy_id', 'raJ2000', 'decJ2000',
                       'minorAxis']
     transformations = {'minorAxis': arcsecFromRadians,
                        'raJ2000': np.degrees,
                        'decJ2000': np.degrees}
+
+
+    def get_objid(self):
+        return np.array([self.db_obj.objectTypeId]*len(self.column_by_name('raJ2000')))
+
+
 
 if __name__ == "__main__":
 

--- a/workspace/compound_db/make_compound_catalog.py
+++ b/workspace/compound_db/make_compound_catalog.py
@@ -1,34 +1,41 @@
 from desc.sims.GCRCatSimInterface import CompoundDESCQAInstanceCatalog
-from desc.sims.GCRCatSimInterface import bulgeDESCQAObject
-from desc.sims.GCRCatSimInterface import diskDESCQAObject
+from desc.sims.GCRCatSimInterface import bulgeDESCQAObject_protoDC2
+from desc.sims.GCRCatSimInterface import diskDESCQAObject_protoDC2
 from desc.sims.GCRCatSimInterface import CompoundDESCQAObject
 from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.utils import ObservationMetaData
+import numpy as np
 
 class _testDESCQAObj(object):
     yaml_file_name = 'proto-dc2_v2.1.2'
+    field_ra = 23.0
+    field_dec = -22.3
 
-class bulgeDESCQAObject_test(_testDESCQAObj, bulgeDESCQAObject):
+class bulgeDESCQAObject_test(_testDESCQAObj, bulgeDESCQAObject_protoDC2):
     objid = 'bulge_descqa'
 
-class diskDESCQAObject_test(_testDESCQAObj, diskDESCQAObject):
+class diskDESCQAObject_test(_testDESCQAObj, diskDESCQAObject_protoDC2):
     objid = 'disk_descqa'
 
 class CatForBulge(InstanceCatalog):
     column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
                       'minorAxis', 'majorAxis']
     transformations = {'minorAxis': arcsecFromRadians,
-                       'majorAxis': arcsecFromRadians}
+                       'majorAxis': arcsecFromRadians,
+                       'raJ2000': np.degrees,
+                       'decJ2000': np.degrees}
 
 class CatForDisk(InstanceCatalog):
     column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
                       'minorAxis']
-    transformations = {'minorAxis': arcsecFromRadians}
+    transformations = {'minorAxis': arcsecFromRadians,
+                       'raJ2000': np.degrees,
+                       'decJ2000': np.degrees}
 
 if __name__ == "__main__":
 
-    obs = ObservationMetaData(pointingRA=0.0, pointingDec=0.0,
+    obs = ObservationMetaData(pointingRA=22.7, pointingDec=-22.7,
                               boundType='circle', boundLength=0.01)
 
     cat = CompoundDESCQAInstanceCatalog([CatForBulge, CatForDisk],

--- a/workspace/compound_db/make_compound_catalog.py
+++ b/workspace/compound_db/make_compound_catalog.py
@@ -1,21 +1,8 @@
-from lsst.sims.catUtils.baseCatalogModels import GalaxyBulgeObj
-from lsst.sims.catUtils.baseCatalogModels import GalaxyDiskObj
-from lsst.sims.catUtils.baseCatalogModels import GalaxyTileCompoundObj
 from lsst.sims.catalogs.definitions import CompoundInstanceCatalog
+from desc.sims.GCRCatSimInterface import bulgeDESCQAObject
+from desc.sims.GCRCatSimInterface import diskDESCQAObject
 from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.utils import ObservationMetaData
-
-class _fatboy(object):
-    database = 'LSSTCATSIM'
-    host = 'fatboy.phys.washington.edu'
-    port = 1433
-    driver = 'mssql+pymssql'
-
-class GalaxyBulgeObj_fatboy(_fatboy, GalaxyBulgeObj):
-    pass
-
-class GalaxyDiskObj_fatboy(_fatboy, GalaxyDiskObj):
-    pass
 
 class CatForBulge(InstanceCatalog):
     cannot_be_null = ['sedFilename']
@@ -33,9 +20,8 @@ if __name__ == "__main__":
                               boundType='circle', boundLength=0.01)
 
     cat = CompoundInstanceCatalog([CatForBulge, CatForDisk],
-                                  [GalaxyBulgeObj_fatboy,
-                                   GalaxyDiskObj_fatboy],
-                                  obs_metadata=obs,
-                                  compoundDBclass=GalaxyTileCompoundObj)
+                                  [bulgeDESCQAObject,
+                                   diskDESCQAObject],
+                                  obs_metadata=obs)
 
-    cat.write_catalog('compound_cat.txt', chunk_size=10000)
+    cat.write_catalog('descqa_compound_cat.txt', chunk_size=10000)

--- a/workspace/compound_db/make_compound_catalog.py
+++ b/workspace/compound_db/make_compound_catalog.py
@@ -1,27 +1,40 @@
-from lsst.sims.catalogs.definitions import CompoundInstanceCatalog
+from desc.sims.GCRCatSimInterface import CompoundDESCQAInstanceCatalog
 from desc.sims.GCRCatSimInterface import bulgeDESCQAObject
 from desc.sims.GCRCatSimInterface import diskDESCQAObject
+from desc.sims.GCRCatSimInterface import CompoundDESCQACatalogDBObject
 from lsst.sims.catalogs.definitions import InstanceCatalog
+from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.utils import ObservationMetaData
 
+class _testDESCQAObj(object):
+    yaml_file_name = 'proto-dc2_v2.1.2'
+
+class bulgeDESCQAObject_test(_testDESCQAObj, bulgeDESCQAObject):
+    objid = 'bulge_descqa'
+
+class diskDESCQAObject_test(_testDESCQAObj, diskDESCQAObject):
+    objid = 'disk_descqa'
+
 class CatForBulge(InstanceCatalog):
-    cannot_be_null = ['sedFilename']
     column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
-                      'sedFilename', 'majorAxis']
+                      'minorAxis', 'majorAxis']
+    transformations = {'minorAxis': arcsecFromRadians,
+                       'majorAxis': arcsecFromRadians}
 
 class CatForDisk(InstanceCatalog):
-    cannot_be_null = ['sedFilename']
     column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
-                      'sedFilename']
+                      'minorAxis']
+    transformations = {'minorAxis': arcsecFromRadians}
 
 if __name__ == "__main__":
 
     obs = ObservationMetaData(pointingRA=0.0, pointingDec=0.0,
                               boundType='circle', boundLength=0.01)
 
-    cat = CompoundInstanceCatalog([CatForBulge, CatForDisk],
-                                  [bulgeDESCQAObject,
-                                   diskDESCQAObject],
-                                  obs_metadata=obs)
+    cat = CompoundDESCQAInstanceCatalog([CatForBulge, CatForDisk],
+                                        [bulgeDESCQAObject_test,
+                                         diskDESCQAObject_test],
+                                        obs_metadata=obs,
+                                        compoundDBclass=CompoundDESCQACatalogDBObject)
 
     cat.write_catalog('descqa_compound_cat.txt', chunk_size=10000)

--- a/workspace/compound_db/make_compound_catalog.py
+++ b/workspace/compound_db/make_compound_catalog.py
@@ -1,7 +1,7 @@
 from desc.sims.GCRCatSimInterface import CompoundDESCQAInstanceCatalog
 from desc.sims.GCRCatSimInterface import bulgeDESCQAObject
 from desc.sims.GCRCatSimInterface import diskDESCQAObject
-from desc.sims.GCRCatSimInterface import CompoundDESCQACatalogDBObject
+from desc.sims.GCRCatSimInterface import CompoundDESCQAObject
 from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.utils import ObservationMetaData
@@ -35,6 +35,6 @@ if __name__ == "__main__":
                                         [bulgeDESCQAObject_test,
                                          diskDESCQAObject_test],
                                         obs_metadata=obs,
-                                        compoundDBclass=CompoundDESCQACatalogDBObject)
+                                        compoundDBclass=CompoundDESCQAObject)
 
     cat.write_catalog('descqa_compound_cat.txt', chunk_size=10000)

--- a/workspace/compound_db/make_compound_catalog.py
+++ b/workspace/compound_db/make_compound_catalog.py
@@ -8,6 +8,10 @@ from lsst.sims.utils import ObservationMetaData
 
 class _testDESCQAObj(object):
     yaml_file_name = 'proto-dc2_v2.1.2'
+    tableid = 'protodc2'
+    raColName = 'ra_true'
+    decColName = 'dec_true'
+    connection = None
 
 class bulgeDESCQAObject_test(_testDESCQAObj, bulgeDESCQAObject):
     objid = 'bulge_descqa'

--- a/workspace/compound_db/make_compound_catalog.py
+++ b/workspace/compound_db/make_compound_catalog.py
@@ -1,0 +1,41 @@
+from lsst.sims.catUtils.baseCatalogModels import GalaxyBulgeObj
+from lsst.sims.catUtils.baseCatalogModels import GalaxyDiskObj
+from lsst.sims.catUtils.baseCatalogModels import GalaxyTileCompoundObj
+from lsst.sims.catalogs.definitions import CompoundInstanceCatalog
+from lsst.sims.catalogs.definitions import InstanceCatalog
+from lsst.sims.utils import ObservationMetaData
+
+class _fatboy(object):
+    database = 'LSSTCATSIM'
+    host = 'fatboy.phys.washington.edu'
+    port = 1433
+    driver = 'mssql+pymssql'
+
+class GalaxyBulgeObj_fatboy(_fatboy, GalaxyBulgeObj):
+    pass
+
+class GalaxyDiskObj_fatboy(_fatboy, GalaxyDiskObj):
+    pass
+
+class CatForBulge(InstanceCatalog):
+    cannot_be_null = ['sedFilename']
+    column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
+                      'sedFilename', 'majorAxis']
+
+class CatForDisk(InstanceCatalog):
+    cannot_be_null = ['sedFilename']
+    column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
+                      'sedFilename']
+
+if __name__ == "__main__":
+
+    obs = ObservationMetaData(pointingRA=0.0, pointingDec=0.0,
+                              boundType='circle', boundLength=0.01)
+
+    cat = CompoundInstanceCatalog([CatForBulge, CatForDisk],
+                                  [GalaxyBulgeObj_fatboy,
+                                   GalaxyDiskObj_fatboy],
+                                  obs_metadata=obs,
+                                  compoundDBclass=GalaxyTileCompoundObj)
+
+    cat.write_catalog('compound_cat.txt', chunk_size=10000)

--- a/workspace/compound_db/verify_compound_catalog.py
+++ b/workspace/compound_db/verify_compound_catalog.py
@@ -1,0 +1,112 @@
+from desc.sims.GCRCatSimInterface import PhoSimDESCQA
+from desc.sims.GCRCatSimInterface import CompoundDESCQAInstanceCatalog
+from desc.sims.GCRCatSimInterface import bulgeDESCQAObject_protoDC2
+from desc.sims.GCRCatSimInterface import diskDESCQAObject_protoDC2
+from desc.sims.GCRCatSimInterface import CompoundDESCQAObject
+from lsst.sims.catUtils.exampleCatalogDefinitions import DefaultPhoSimHeaderMap
+from lsst.sims.utils import arcsecFromRadians
+from lsst.sims.utils import ObservationMetaData
+import numpy as np
+import os
+
+class _testDESCQAObj(object):
+    yaml_file_name = 'proto-dc2_v2.1.2'
+    field_ra = 23.0
+    field_dec = -22.3
+
+
+# use different DESCQAObject classes with different
+# _cat_cache_suffixes for baseline and test to force
+# the CompoundDESCQAInstanceCatalog to load the catalog
+# and apply the rotation itself
+
+class bulgeDESCQAObject_baseline(_testDESCQAObj, bulgeDESCQAObject_protoDC2):
+    _cat_cache_suffix = 'rot_baseline'
+
+class diskDESCQAObject_baseline(_testDESCQAObj, diskDESCQAObject_protoDC2):
+    _cat_cache_suffix = 'rot_baseline'
+
+class bulgeDESCQAObject_test(_testDESCQAObj, bulgeDESCQAObject_protoDC2):
+    objid = 'bulge_descqa'
+    _cat_cache_suffix = 'rot_test'
+
+class diskDESCQAObject_test(_testDESCQAObj, diskDESCQAObject_protoDC2):
+    objid = 'disk_descqa'
+    _cat_cache_suffix = 'rot_test'
+
+class PhoSimDESCQABulge(PhoSimDESCQA):
+    cannot_be_null = ['hasBulge']
+
+class PhoSimDESCQADisk(PhoSimDESCQA):
+    cannot_be_null = ['hasDisk']
+
+
+if __name__ == "__main__":
+
+    obs = ObservationMetaData(pointingRA=22.7, pointingDec=-22.7,
+                              boundType='circle', boundLength=0.01,
+                              mjd=59981.2, bandpassName='g',
+                              rotSkyPos=18.6)
+
+    out_dir = 'compound_verification_dir'
+    if not os.path.exists(out_dir):
+        os.mkdir(out_dir)
+    else:
+        if not os.path.isdir(out_dir):
+            raise RuntimeError('%s is not a dir' % out_dir)
+
+    # first, write out the two InstanceCatalogs separately
+    bulge_db = bulgeDESCQAObject_baseline()
+    bulge_cat = PhoSimDESCQABulge(bulge_db, obs_metadata=obs)
+    bulge_cat_name = os.path.join(out_dir, 'bulge_baseline.txt')
+    bulge_cat.phoSimHeaderMap = DefaultPhoSimHeaderMap
+    bulge_cat.write_catalog(bulge_cat_name, chunk_size=10000)
+
+    disk_db = diskDESCQAObject_baseline()
+    disk_cat = PhoSimDESCQADisk(disk_db, obs_metadata=obs)
+    disk_cat_name = os.path.join(out_dir, 'disk_baseline.txt')
+    disk_cat.phoSimHeaderMap = DefaultPhoSimHeaderMap
+    disk_cat.write_catalog(disk_cat_name, chunk_size=10000)
+
+    baseline_lines = set()
+    with open(bulge_cat_name, 'r') as in_file:
+        for line in in_file:
+            baseline_lines.add(line)
+
+    assert len(baseline_lines) > 100
+    i0 = len(baseline_lines)
+
+    with open(disk_cat_name, 'r') as in_file:
+        for line in in_file:
+            baseline_lines.add(line)
+
+    assert len(baseline_lines) > (i0+100)
+
+    # now, write the same catalogs with the CompoundDESCQAInstanceCatalog
+    cat = CompoundDESCQAInstanceCatalog([PhoSimDESCQABulge,
+                                         PhoSimDESCQADisk],
+                                        [bulgeDESCQAObject_test,
+                                         diskDESCQAObject_test],
+                                        obs_metadata=obs,
+                                        compoundDBclass=CompoundDESCQAObject)
+
+    cat.phoSimHeaderMap = DefaultPhoSimHeaderMap
+
+    compound_name = os.path.join(out_dir, 'compound_cat.txt')
+    cat.write_catalog(compound_name, chunk_size=10000)
+
+    n_rows = 0
+    with open(compound_name, 'r') as in_file:
+        for line in in_file:
+            try:
+                assert line in baseline_lines
+            except AssertionErrro:
+                print('\n\n%s\n\nmissing\n' % line)
+                raise
+            n_rows += 1
+
+    # because baseline_lines is a set and sets do not allow
+    # duplicate entries, the header lines, which should be
+    # identical in both the bulge and the disk catalogs,
+    # will only appear once in baseline_lines
+    assert n_rows == len(baseline_lines)


### PR DESCRIPTION
As you may recall, in order to run the sprinkler in Twinkles, we had to create a structure that simultaneously queried the galaxy_disk, galaxy_bulge, and galaxy_agn tables on fatboy so that the sprinkler could self-consistently remove all of the components of the relevant galaxies.  This pull request extends that infrastructure to the GCRCatSimInterface.

The scripts `workspace/compound_db/make_compound_catalog.py` and `workspace/compound_db/verify_compound_catalog.py` show how this works.  The only major design changes is that `yaml_file_name`, `field_ra` and `field_dec` need to be defined in the `DESCQAObject` daughter classes at class definition time, rather than at instantiation.

`workspace/compound_db/verify_compound_catalog.py` verifies that this PR behaves the way it should by generating a PhoSim InstanceCatalog of bulges and a PhoSim InstanceCatalog of disks, and then generating both again with the CompoundCatalog framework and verifying that the contents of all three catalogs are consistent.  We can move this to a test directory, if we want to. It involves actually loading `proto-dc2_v2.1.2`, so I don't know if we want to treat it as an actual unit test or not (someday we should think about how to generate dummy GCR catalogs the same way we generate dummy SQL catalogs for unit testing purposes in `lsst_sims`).

Let me know what changes you think should be made before merging.

Also, Bryce Kalmbach should know about this, since he is actively working on extending the sprinkler now.  I emailed him.  He does not seem to be associated with this repo (at least, I cannot @ him or add him as reviewer).