### PR TITLE
Changes to modify sed filepath as described in issue:

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -35,7 +35,7 @@ class DC2PhosimCatalogSN(PhoSimCatalogSN):
         a phosim catalog.
         """
         fnames = self.column_by_name('sedFilepath')
-        sep = 'specFileSN_'
+        sep = 'Dynamic/specFileSN_'
         split_names = []
         for fname in fnames:
             if 'None' not in fname:

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -189,7 +189,7 @@ class InstanceCatalogWriter(object):
 
         obs_md = get_obs_md(self.obs_gen, obsHistID, fov, dither=self.dither)
         # Add directory
-        twinkles_spec_map.subdir_map['(^specFile_)'] = out_dir
+        twinkles_spec_map.subdir_map['(^specFile_)'] = str(os.path.join(out_dir, 'Dynamic'))
 
         cat_name = 'phosim_cat_%d.txt' % obsHistID
         star_name = 'star_cat_%d.txt' % obsHistID
@@ -289,6 +289,8 @@ class InstanceCatalogWriter(object):
                                                    field_ra=self.protoDC2_ra,
                                                    field_dec=self.protoDC2_dec,
                                                    agn_params_db=self.agn_db_name)
+
+            gal_cat.use_spec_map = twinkles_spec_map
 
             gal_cat.write_catalog(os.path.join(out_dir, gal_name), chunk_size=100000,
                                   write_header=False)

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -190,7 +190,7 @@ class InstanceCatalogWriter(object):
         obs_md = get_obs_md(self.obs_gen, obsHistID, fov, dither=self.dither)
         # Add directory for writing the GLSN spectra to
         glsn_spectra_dir = str(os.path.join(out_dir, 'Dynamic'))
-        twinkles_spec_map.subdir_map['(^specFileGLSN)'] = glsn_spectra_dir
+        twinkles_spec_map.subdir_map['(^specFileGLSN)'] = 'Dynamic'
         # Ensure that the directory for GLSN spectra is created
         os.makedirs(glsn_spectra_dir, exist_ok=True)
 
@@ -294,6 +294,7 @@ class InstanceCatalogWriter(object):
                                                    agn_params_db=self.agn_db_name)
 
             gal_cat.use_spec_map = twinkles_spec_map
+            gal_cat.sed_dir = glsn_spectra_dir
 
             gal_cat.write_catalog(os.path.join(out_dir, gal_name), chunk_size=100000,
                                   write_header=False)

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -28,6 +28,7 @@ from . import bulgeDESCQAObject_protoDC2 as bulgeDESCQAObject, \
     sprinklerCompound_DC2 as sprinklerDESCQACompoundObject, \
     TwinklesCatalogZPoint_DC2 as DESCQACat_Twinkles
 from . import DC2PhosimCatalogSN, SNFileDBObject
+from .TwinklesClasses import twinkles_spec_map
 
 __all__ = ['InstanceCatalogWriter', 'make_instcat_header', 'get_obs_md',
            'snphosimcat']
@@ -187,6 +188,8 @@ class InstanceCatalogWriter(object):
             os.mkdir(out_dir)
 
         obs_md = get_obs_md(self.obs_gen, obsHistID, fov, dither=self.dither)
+        # Add directory
+        twinkles_spec_map.subdir_map['(^specFile_)'] = out_dir
 
         cat_name = 'phosim_cat_%d.txt' % obsHistID
         star_name = 'star_cat_%d.txt' % obsHistID
@@ -297,6 +300,7 @@ class InstanceCatalogWriter(object):
                                         objectIDtype=i+42)
 
             snOutFile = names[i] +'_cat_{}.txt'.format(obsHistID)  
+            print('writing out catalog ', snOutFile)
             phosimcatalog.write_catalog(os.path.join(out_dir, snOutFile),
                                         chunk_size=10000, write_header=False)
 

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -188,8 +188,11 @@ class InstanceCatalogWriter(object):
             os.mkdir(out_dir)
 
         obs_md = get_obs_md(self.obs_gen, obsHistID, fov, dither=self.dither)
-        # Add directory
-        twinkles_spec_map.subdir_map['(^specFileGLSN)'] = str(os.path.join(out_dir, 'Dynamic'))
+        # Add directory for writing the GLSN spectra to
+        glsn_spectra_dir = str(os.path.join(out_dir, 'Dynamic'))
+        twinkles_spec_map.subdir_map['(^specFileGLSN)'] = glsn_spectra_dir
+        # Ensure that the directory for GLSN spectra is created
+        os.makedirs(glsn_spectra_dir, exist_ok=True)
 
         cat_name = 'phosim_cat_%d.txt' % obsHistID
         star_name = 'star_cat_%d.txt' % obsHistID

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -189,7 +189,7 @@ class InstanceCatalogWriter(object):
 
         obs_md = get_obs_md(self.obs_gen, obsHistID, fov, dither=self.dither)
         # Add directory
-        twinkles_spec_map.subdir_map['(^specFile_)'] = str(os.path.join(out_dir, 'Dynamic'))
+        twinkles_spec_map.subdir_map['(^specFileGLSN)'] = str(os.path.join(out_dir, 'Dynamic'))
 
         cat_name = 'phosim_cat_%d.txt' % obsHistID
         star_name = 'star_cat_%d.txt' % obsHistID

--- a/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
@@ -32,13 +32,15 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
     agn_cache_file = _agn_cache_file
     sne_cache_file = _sne_cache_file
     defs_file = _twinkles_defs_file
+    sed_dir = 'Dynamic'
 
     agn_objid = 'agn_descqa'
 
     def _final_pass(self, results):
 
         #Use Sprinkler now
-        sp = sprinkler(results, self.mjd, self.specFileMap, density_param=1.0,
+        sp = sprinkler(results, self.mjd, self.specFileMap, self.sed_dir,
+                       density_param=1.0,
                        cached_sprinkling=self.cached_sprinkling,
                        agn_cache_file=self.agn_cache_file,
                        sne_cache_file=self.sne_cache_file,
@@ -167,6 +169,7 @@ class TwinklesCompoundInstanceCatalog_DC2(CompoundDESCQAInstanceCatalog):
                 compound_dbo.agn_params_db = self._agn_params_db
                 compound_dbo.mjd = self._obs_metadata.mjd.TAI
                 compound_dbo.specFileMap = twinkles_spec_map
+                compound_dbo.sed_dir = self.sed_dir
 
                 self._write_compound(catList, compound_dbo, filename,
                                      chunk_size=chunk_size, write_header=write_header,


### PR DESCRIPTION
- Added a parameter to the factory method `snphosimcat` to pass in the
  script output directory to set directory of spectra relative to that.
- Changed the `sn_sedfile_prefix` of the created catalogs to combine the
  input `sedRootDir` into the directory of spectra
- Pass the output directory `out_dir` to the `snphosimcat` factory
  functions from `InstanceCatalogWriter`
- formatting changes
	modified:   InstanceCatalogWriter.py
- Changed the separator variable in  `getsthorterFileNames` method of `D2PhosimCatalogSN` mixin
	modified:   CatalogClasses.py
This is the SN part. We also need this for lensed SN.  @jbkalmbach 