### PR TITLE
change proto-dc2_v2.1.2 to protoDC2

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/ProtoDC2DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/ProtoDC2DatabaseEmulator.py
@@ -151,7 +151,7 @@ class DESCQAObject_protoDC2(DESCQAObject):
     _cat_cache_suffix = '_rotated'
     tableid = 'galaxy'
     database = 'LSSTCATSIM'
-    yaml_file_name = 'proto-dc2_v2.1.2'
+    yaml_file_name = 'protoDC2'
 
     def _rotate_to_correct_field(self, ra_rad, dec_rad):
         """

--- a/tests/test_full_instanceCatalogs.py
+++ b/tests/test_full_instanceCatalogs.py
@@ -37,7 +37,7 @@ class BulgePhoSimCatalogTestCase(unittest.TestCase):
         ObservationMetaData, using protoDC2 (to make sure we don't
         break the whole interface)
         """
-        db = diskDESCQAObject_protoDC2(yaml_file_name='proto-dc2_v2.1.2')
+        db = diskDESCQAObject_protoDC2(yaml_file_name='protoDC2')
         db.field_ra = self.field_ra
         db.field_dec = self.field_dec
         obs = ObservationMetaData(pointingRA=self.field_ra+0.2,
@@ -63,7 +63,7 @@ class BulgePhoSimCatalogTestCase(unittest.TestCase):
         """
         Test that DESCQAObjects now return varParamStr='None' by default
         """
-        db = diskDESCQAObject_protoDC2(yaml_file_name='proto-dc2_v2.1.2')
+        db = diskDESCQAObject_protoDC2(yaml_file_name='protoDC2')
         db.field_ra = self.field_ra
         db.field_dec = self.field_dec
 

--- a/workspace/agn_params/test_agn_catalog.py
+++ b/workspace/agn_params/test_agn_catalog.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     ra = 112.0
     dec = -75.0
 
-    db = agnDESCQAObject_protoDC2(yaml_file_name='proto-dc2_v2.1.2')
+    db = agnDESCQAObject_protoDC2(yaml_file_name='protoDC2')
 
     agn_db_name = os.path.join(os.environ['SCRATCH'], 'proto_dc2_agn',
                                'test_agn.db')

--- a/workspace/agn_params/test_agn_compound.py
+++ b/workspace/agn_params/test_agn_compound.py
@@ -15,7 +15,7 @@ global_agn_params_db = os.path.join('/global/cscratch1/sd/danielsf/',
 assert os.path.exists(global_agn_params_db)
 
 class _testDESCQAObj(object):
-    yaml_file_name = 'proto-dc2_v2.1.2'
+    yaml_file_name = 'protoDC2'
     field_ra = 23.0
     field_dec = -22.3
 

--- a/workspace/agn_params/test_phosim_agn_catalog.py
+++ b/workspace/agn_params/test_phosim_agn_catalog.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     ra = 112.0
     dec = -75.0
 
-    db = agnDESCQAObject_protoDC2(yaml_file_name='proto-dc2_v2.1.2')
+    db = agnDESCQAObject_protoDC2(yaml_file_name='protoDC2')
 
     agn_db_name = os.path.join(os.environ['SCRATCH'], 'proto_dc2_agn',
                                'test_agn.db')

--- a/workspace/compound_db/make_compound_catalog.py
+++ b/workspace/compound_db/make_compound_catalog.py
@@ -8,7 +8,7 @@ from lsst.sims.utils import ObservationMetaData
 import numpy as np
 
 class _testDESCQAObj(object):
-    yaml_file_name = 'proto-dc2_v2.1.2'
+    yaml_file_name = 'protoDC2'
     field_ra = 23.0
     field_dec = -22.3
 

--- a/workspace/compound_db/verify_compound_catalog.py
+++ b/workspace/compound_db/verify_compound_catalog.py
@@ -10,7 +10,7 @@ import numpy as np
 import os
 
 class _testDESCQAObj(object):
-    yaml_file_name = 'proto-dc2_v2.1.2'
+    yaml_file_name = 'protoDC2'
     field_ra = 23.0
     field_dec = -22.3
 

--- a/workspace/instcat_writer/test_instance_catalog_writer.py
+++ b/workspace/instcat_writer/test_instance_catalog_writer.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
 
     assert os.path.exists(agn_db_name)
 
-    ic_writer = InstanceCatalogWriter(opsim_db_name, 'proto-dc2_v2.1.2',
+    ic_writer = InstanceCatalogWriter(opsim_db_name, 'protoDC2',
                                       protoDC2_ra=53.0, protoDC2_dec=-28.0,
                                       agn_db_name=agn_db_name,
                                       sprinkler=True,


### PR DESCRIPTION
This PR fixes #18 by replacing all occurrence of `proto-dc2_v2.1.2` to `protoDC2`. See the discussion in #18 for details. 