### PR TITLE
U/danielsf/debug/dust columns

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+import copy
 from .SedFitter import sed_from_galacticus_mags
 from lsst.utils import getPackageDir
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogSersic2D
@@ -123,12 +124,12 @@ class PhoSimDESCQA(PhoSimCatalogSersic2D, EBVmixin):
         av_name = 'A_v_%s' % lum_type
         if av_name not in self._all_available_columns:
             av_name = 'A_v'
-        av_list = self.column_by_name(av_name)
+        av_list = copy.copy(self.column_by_name(av_name))
 
         rv_name = 'R_v_%s' % lum_type
         if rv_name not in self._all_available_columns:
             rv_name = 'R_v'
-        rv_list = self.column_by_name(rv_name)
+        rv_list = copy.copy(self.column_by_name(rv_name))
 
         # this is a hack to replace anomalous values of dust extinction
         # with more reasonable values

--- a/workspace/instcat_writer/test_instance_catalog_writer.py
+++ b/workspace/instcat_writer/test_instance_catalog_writer.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
 
     assert os.path.exists(agn_db_name)
 
-    ic_writer = InstanceCatalogWriter(opsim_db_name, 'protoDC2',
+    ic_writer = InstanceCatalogWriter(opsim_db_name, 'proto-dc2_v3.0',
                                       protoDC2_ra=53.0, protoDC2_dec=-28.0,
                                       agn_db_name=agn_db_name,
                                       sprinkler=True,


### PR DESCRIPTION
This change is needed to prevent a crash because numpy arrays returned directly by the Generic Catalog Reader are read-only.

We should investigate whether the code to deal with nonsense Av and Rv values is still necessary, now that we are past protoDC2-v2.1.2