### PR TITLE
Fixed CCM string to 'none' by changing default columns. Tested on cori.

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -60,7 +60,7 @@ class DC2PhosimCatalogSN(PhoSimCatalogSN):
                        ('raOffset', 0., float), ('decOffset', 0., float),
                        ('galacticAv', 0.1, float), ('galacticRv', 3.1, float),
                        ('galacticExtinctionModel', 'CCM', (str, 3)),
-                       ('internalExtinctionModel', 'CCM', (str, 3)), ('internalAv', 0., float),
+                       ('internalExtinctionModel', 'none', (str, 4)), ('internalAv', 0., float),
                        ('internalRv', 3.1, float), ('shear1', 0., float), ('shear2', 0., float)]
 
 


### PR DESCRIPTION
and found test scripts to work:
	modified:   CatalogClasses.py

The output is now of the form:
```
object 32011307 53.3526927 -28.2014438 29.4820118
Dynamic/specFileSN_31261_59844.2240_r.dat 0.965175454 0 0 0 0 0 point
none CCM 0.0280743331 3.1
```


Fixes #35 