### PR TITLE
sed label names change in GCRCatalogs v0.7.4

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/SedFitter.py
+++ b/python/desc/sims/GCRCatSimInterface/SedFitter.py
@@ -32,8 +32,8 @@ def sed_filter_names_from_catalog(catalog):
     All outputs will be returned in order of increasing wav_min
     """
 
-    disk_re = re.compile(r'sed_(\d+)_(\d+)_disk$')
-    bulge_re = re.compile(r'sed_(\d+)_(\d+)_bulge$')
+    disk_re = re.compile(r'sed_(\d+)_(\d+)_disk_no_host_extinction$')
+    bulge_re = re.compile(r'sed_(\d+)_(\d+)_bulge_no_host_extinction$')
 
     all_quantities = catalog.list_all_quantities()
 


### PR DESCRIPTION
Starting from GCRCatalogs v0.7.4, the SED label names that CatSim needs have been changed. See https://github.com/LSSTDESC/gcr-catalogs/issues/104 https://github.com/LSSTDESC/gcr-catalogs/issues/105 for details.

This PR makes the corresponding changes in this interface. 