### PR TITLE
U/danielsf/sprinkled/truth

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -37,7 +37,7 @@ class TruthCatalogMixin(object):
 
     cannot_be_null = ['sprinkling_switch']
 
-    _file_handle = None
+    _truth_file_handle = None
 
     @cached
     def get_sprinkling_switch(self):
@@ -57,24 +57,25 @@ class TruthCatalogMixin(object):
         file_handle points to the InstanceCatalog for which this
         catalog contains truth information
         """
-        if self._file_handle is None:
+        if self._truth_file_handle is None:
             file_dir = os.path.dirname(file_handle.name)
             instcat_name = os.path.basename(file_handle.name)
             truth_name = os.path.join(file_dir,
                                       'truth_%s' % instcat_name)
 
             assert truth_name != file_handle.name
-            self._file_handle = open(truth_name, 'a')
+            self._truth_file_handle = open(truth_name, 'a')
 
             # call InstanceCatalog.write_header to avoid calling
             # the PhoSim catalog write_header (which will require
             # a phoSimHeaderMap)
-            InstanceCatalog.write_header(self, self._file_handle)
+            InstanceCatalog.write_header(self, self._truth_file_handle)
 
             print('writing %d' % len(local_recarray))
             print(local_recarray.dtype.names)
 
-        InstanceCatalog._write_recarray(self, local_recarray, self._file_handle)
+        InstanceCatalog._write_recarray(self, local_recarray,
+                                        self._truth_file_handle)
 
 
 class DC2PhosimCatalogSN(PhoSimCatalogSN):

--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -31,7 +31,7 @@ class TruthCatalogMixin(object):
     with something that will write a separate truth catalog.
     """
 
-    column_outputs = ['raJ2000', 'decJ2000',
+    column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
                       'sedFilepath', 'phoSimMagNorm',
                       'redshift']
 

--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -188,29 +188,32 @@ class PhoSimDESCQA(PhoSimCatalogSersic2D, EBVmixin):
                                'or a bulge catalog\n'
                                'self._cannot_be_null %s' % self._cannot_be_null)
 
-        av_name = 'A_v_%s' % lum_type
-        if av_name not in self._all_available_columns:
-            av_name = 'A_v'
-        av_list = copy.copy(self.column_by_name(av_name))
-
-        rv_name = 'R_v_%s' % lum_type
-        if rv_name not in self._all_available_columns:
-            rv_name = 'R_v'
-        rv_list = copy.copy(self.column_by_name(rv_name))
-
         # this is a hack to replace anomalous values of dust extinction
         # with more reasonable values
         if not hasattr(self, '_dust_rng'):
             self._dust_rng = np.random.RandomState(182314)
 
-        offensive_av = np.where(np.logical_or(np.isnan(av_list),
-                                np.logical_or(av_list<0.001, av_list>3.1)))
+        # temporarily suppress divide by zero warnings
+        with np.errstate(divide='ignore', invalid='ignore'):
+            av_name = 'A_v_%s' % lum_type
+            if av_name not in self._all_available_columns:
+                av_name = 'A_v'
+            av_list = copy.copy(self.column_by_name(av_name))
 
-        av_list[offensive_av] = self._dust_rng.random_sample(len(offensive_av[0]))*3.1+0.001
+            rv_name = 'R_v_%s' % lum_type
+            if rv_name not in self._all_available_columns:
+                rv_name = 'R_v'
+            rv_list = copy.copy(self.column_by_name(rv_name))
 
-        offensive_rv = np.where(np.logical_or(np.isnan(rv_list),
-                                np.logical_or(rv_list<1.0, rv_list>5.0)))
-        rv_list[offensive_rv] = self._dust_rng.random_sample(len(offensive_rv[0]))*4.0+1.0
+            offensive_av = np.where(np.logical_or(np.isnan(av_list),
+                                    np.logical_or(av_list<0.001, av_list>3.1)))
+
+            av_list[offensive_av] = self._dust_rng.random_sample(len(offensive_av[0]))*3.1+0.001
+
+            offensive_rv = np.where(np.logical_or(np.isnan(rv_list),
+                                    np.logical_or(rv_list<1.0, rv_list>5.0)))
+
+            rv_list[offensive_rv] = self._dust_rng.random_sample(len(offensive_rv[0]))*4.0+1.0
 
         return np.array([av_list, rv_list])
 

--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -236,6 +236,7 @@ class PhoSimDESCQA(PhoSimCatalogSersic2D, EBVmixin):
         Need to leave this method here to overload the get_phoSimMagNorm
         in the base PhoSim InstanceCatalog classes
         """
+        self.column_by_name('is_sprinkled')
         return self.column_by_name('magNorm')
 
 class PhoSimDESCQA_AGN(PhoSimCatalogZPoint, EBVmixin, VariabilityAGN):

--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -31,6 +31,10 @@ class TruthCatalogMixin(object):
     with something that will write a separate truth catalog.
     """
 
+    column_outputs = ['raJ2000', 'decJ2000',
+                      'sedFilepath', 'phoSimMagNorm',
+                      'redshift']
+
     cannot_be_null = ['sprinkling_switch']
 
     _file_handle = None
@@ -295,8 +299,7 @@ class PhoSimDESCQA(PhoSimCatalogSersic2D, EBVmixin):
 
 
 class TruthPhoSimDESCQA(TruthCatalogMixin, PhoSimDESCQA):
-    column_outputs = ['raJ2000', 'decJ2000', 'sedFilepath', 'phoSimMagNorm']
-
+    pass
 
 class PhoSimDESCQA_AGN(PhoSimCatalogZPoint, EBVmixin, VariabilityAGN):
 
@@ -310,4 +313,4 @@ class PhoSimDESCQA_AGN(PhoSimCatalogZPoint, EBVmixin, VariabilityAGN):
 
 
 class TruthPhoSimDESCQA_AGN(TruthCatalogMixin, PhoSimDESCQA_AGN):
-    column_outputs = ['raJ2000', 'decJ2000', 'sedFilepath', 'phoSimMagNorm']
+    pass

--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -31,7 +31,7 @@ class TruthCatalogMixin(object):
     with something that will write a separate truth catalog.
     """
 
-    column_outputs = ['uniqueId', 'raJ2000', 'decJ2000',
+    column_outputs = ['uniqueId', 'galaxy_id', 'raJ2000', 'decJ2000',
                       'sedFilepath', 'phoSimMagNorm',
                       'redshift']
 

--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -33,7 +33,7 @@ class TruthCatalogMixin(object):
 
     column_outputs = ['uniqueId', 'galaxy_id', 'raJ2000', 'decJ2000',
                       'sedFilepath', 'phoSimMagNorm',
-                      'redshift']
+                      'redshift', 'isPoint']
 
     cannot_be_null = ['sprinkling_switch']
 

--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -242,3 +242,9 @@ class PhoSimDESCQA(PhoSimCatalogSersic2D, EBVmixin):
 class PhoSimDESCQA_AGN(PhoSimCatalogZPoint, EBVmixin, VariabilityAGN):
 
     cannot_be_null = ['sedFilepath', 'magNorm']
+
+    @cached
+    def get_prefix(self):
+        self.column_by_name('is_sprinkled')
+        chunkiter = range(len(self.column_by_name(self.refIdCol)))
+        return np.array(['object' for i in chunkiter], dtype=(str, 6))

--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -50,13 +50,7 @@ class TruthCatalogMixin(object):
     @cached
     def get_sprinkling_switch(self):
         is_sprinkled = self.column_by_name('is_sprinkled')
-        result = np.where(is_sprinkled==1, 1, None)
-        ct_valid =0;
-        for rr in result:
-            if rr is not None:
-                ct_valid+=1
-        print('sprinkled ct_valid %d\n' % ct_valid)
-        return result
+        return np.where(is_sprinkled==1, 1, None)
 
     def _write_recarray(self, local_recarray, file_handle):
         """
@@ -85,9 +79,6 @@ class TruthCatalogMixin(object):
                 # the PhoSim catalog write_header (which will require
                 # a phoSimHeaderMap)
                 InstanceCatalog.write_header(self, self._truth_file_handle)
-
-            print('writing %d' % len(local_recarray))
-            print(local_recarray.dtype.names)
 
         InstanceCatalog._write_recarray(self, local_recarray,
                                         self._truth_file_handle)

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -124,7 +124,9 @@ class DESCQAChunkIterator(object):
             dtype_list = [(name, chunk.dtype[name]) for name in chunk.dtype.names]
             for name in self._colnames:
                 if not descqa_catalog.has_quantity(self._column_map[name][0]):
-                    dtype_list.append((name, self._default_values[name][1]))
+                    dtype_tuple = (name, self._default_values[name][1])
+                    if dtype_tuple not in dtype_list:
+                        dtype_list.append(dtype_tuple)
 
             new_dtype = np.dtype(dtype_list)
 

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -109,9 +109,11 @@ class DESCQAChunkIterator(object):
 
         self._data_indices = self._data_indices[self._chunk_size:]
 
-        chunk = dict_to_numpy_array({name: self._descqa_obj._catalog[self._column_map[name][0]][data_indices_this]
-                                    for name in self._colnames
-                                    if descqa_catalog.has_quantity(self._column_map[name][0])})
+        # temporarily suppress divide by zero warnings
+        with np.errstate(divide='ignore', invalid='ignore'):
+            chunk = dict_to_numpy_array({name: self._descqa_obj._catalog[self._column_map[name][0]][data_indices_this]
+                                        for name in self._colnames
+                                        if descqa_catalog.has_quantity(self._column_map[name][0])})
 
         need_to_append_defaults = False
         for name in self._colnames:

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -184,7 +184,8 @@ class DESCQAObject(object):
     # default value. The second element of the tuple is
     # the dtype of the value (i.e. the argument that gets
     # passed to np.dtype())
-    descqaDefaultValues = {'internalRv_dc2': (np.NaN, float),
+    descqaDefaultValues = {'is_sprinkled': (0, int),
+                           'internalRv_dc2': (np.NaN, float),
                            'internalAv_dc2': (np.NaN, float),
                            'sedFilename_dc2': (None, (str, 200)),
                            'magNorm_dc2': (np.NaN, float),

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -479,7 +479,7 @@ class SprinklerTruthDiskCat(TruthPhoSimDESCQA):
     cannot_be_null = ['hasDisk', 'magNorm', 'sprinkling_switch']
 
 class SprinklerTruthAgnCat(TruthCatalogMixin, DESCQACat_Twinkles):
-    cannot_be_null = ['sprinkling_switch', 'phoSimMagNorm']
+    cannot_be_null = ['sprinkling_switch', 'magNorm']
 
 class MaskedPhoSimCatalogPoint(VariabilityStars, PhoSimCatalogPoint):
     disable_proper_motion = False

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -479,7 +479,7 @@ class SprinklerTruthDiskCat(TruthPhoSimDESCQA):
     cannot_be_null = ['hasDisk', 'magNorm', 'sprinkling_switch']
 
 class SprinklerTruthAgnCat(TruthCatalogMixin, DESCQACat_Twinkles):
-    cannot_be_null = ['sprinkling_switch']
+    cannot_be_null = ['sprinkling_switch', 'phoSimMagNorm']
 
 class MaskedPhoSimCatalogPoint(VariabilityStars, PhoSimCatalogPoint):
     disable_proper_motion = False

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -308,8 +308,8 @@ class InstanceCatalogWriter(object):
             self.compoundGalICList = [self.instcats.DESCQACat_Bulge,
                                       self.instcats.DESCQACat_Disk,
                                       self.instcats.DESCQACat_Twinkles,
-                                      SprinklerTruthBulgeCat,
-                                      SprinklerTruthDiskCat,
+                                      SprinklerTruthSersicCat,
+                                      SprinklerTruthSersicCat,
                                       SprinklerTruthAgnCat]
             self.compoundGalDBList = [bulgeDESCQAObject,
                                       diskDESCQAObject,
@@ -472,14 +472,19 @@ class DESCQACat_Disk(PhoSimDESCQA):
 
     cannot_be_null=['hasDisk', 'magNorm']
 
-class SprinklerTruthBulgeCat(TruthPhoSimDESCQA):
+class SprinklerTruthSersicCat(TruthPhoSimDESCQA):
     cannot_be_null=['hasBulge', 'magNorm', 'sprinkling_switch']
 
-class SprinklerTruthDiskCat(TruthPhoSimDESCQA):
-    cannot_be_null = ['hasDisk', 'magNorm', 'sprinkling_switch']
+    def get_isPoint(self):
+        unq = self.column_by_name('uniqueId')
+        return np.zeros(len(unq), dtype=int)
 
 class SprinklerTruthAgnCat(TruthCatalogMixin, DESCQACat_Twinkles):
     cannot_be_null = ['sprinkling_switch', 'magNorm']
+
+    def get_isPoint(self):
+        unq = self.column_by_name('uniqueId')
+        return np.ones(len(unq), dtype=int)
 
 class MaskedPhoSimCatalogPoint(VariabilityStars, PhoSimCatalogPoint):
     disable_proper_motion = False

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -24,6 +24,7 @@ from lsst.sims.catUtils.mixins import VariabilityStars
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from lsst.sims.utils import arcsecFromRadians, _getRotSkyPos
 from . import PhoSimDESCQA, PhoSimDESCQA_AGN
+from . import TruthPhoSimDESCQA, TruthCatalogMixin
 from . import bulgeDESCQAObject_protoDC2 as bulgeDESCQAObject, \
     diskDESCQAObject_protoDC2 as diskDESCQAObject, \
     knotsDESCQAObject_protoDC2 as knotsDESCQAObject, \
@@ -304,9 +305,16 @@ class InstanceCatalogWriter(object):
             cat.lsstBandpassDict = self.bp_dict
         else:
 
-            self.compoundGalICList = [self.instcats.DESCQACat_Bulge, self.instcats.DESCQACat_Disk,
-                                      self.instcats.DESCQACat_Twinkles]
+            self.compoundGalICList = [self.instcats.DESCQACat_Bulge,
+                                      self.instcats.DESCQACat_Disk,
+                                      self.instcats.DESCQACat_Twinkles,
+                                      SprinklerTruthBulgeCat,
+                                      SprinklerTruthDiskCat,
+                                      SprinklerTruthAgnCat]
             self.compoundGalDBList = [bulgeDESCQAObject,
+                                      diskDESCQAObject,
+                                      agnDESCQAObject,
+                                      bulgeDESCQAObject,
                                       diskDESCQAObject,
                                       agnDESCQAObject]
 
@@ -463,6 +471,15 @@ class DESCQACat_Bulge(PhoSimDESCQA):
 class DESCQACat_Disk(PhoSimDESCQA):
 
     cannot_be_null=['hasDisk', 'magNorm']
+
+class SprinklerTruthBulgeCat(TruthPhoSimDESCQA):
+    cannot_be_null=['hasBulge', 'magNorm', 'sprinkling_switch']
+
+class SprinklerTruthDiskCat(TruthPhoSimDESCQA):
+    cannot_be_null = ['hasDisk', 'magNorm', 'sprinkling_switch']
+
+class SprinklerTruthAgnCat(TruthCatalogMixin, DESCQACat_Twinkles):
+    cannot_be_null = ['sprinkling_switch']
 
 class MaskedPhoSimCatalogPoint(VariabilityStars, PhoSimCatalogPoint):
     disable_proper_motion = False

--- a/python/desc/sims/GCRCatSimInterface/ProtoDC2DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/ProtoDC2DatabaseEmulator.py
@@ -326,7 +326,8 @@ class agnDESCQAObject_protoDC2(AGN_postprocessing_mixin, DESCQAObject_protoDC2):
     objid = 'agn_descqa'
     _columns_need_postfix = False
 
-    descqaDefaultValues = {'varParamStr': (None, (str, 500)),
+    descqaDefaultValues = {'is_sprinkled': (0, int),
+                           'varParamStr': (None, (str, 500)),
                            'magNorm': (np.NaN, np.float),
                            'sedFilename': ('agn.spec', (str, 500))}
 

--- a/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
@@ -61,6 +61,19 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
         print(len(results))
         print('\n\n\n')
 
+        # copy results from the InstanceCatalog queries
+        # into the truth_* catalog queries
+        column_name_list = results.dtype.names
+        for name in column_name_list:
+            if name.startswith('truth'):
+                continue
+            truth_name = 'truth_%s' % name
+            if truth_name not in column_name_list:
+                continue
+
+            print('copying %s from %s' % (truth_name, name))
+            results[truth_name] = results[name]
+
         return results
 
 class TwinklesCatalogSersic2D_DC2(PhoSimDESCQA):

--- a/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
@@ -37,13 +37,6 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
     agn_objid = 'agn_descqa'
 
     def _final_pass(self, results):
-        print('\n\n\nsprinkling')
-        name_list = results.dtype.names
-        for name in name_list:
-            if 'sprinkled' in name:
-                print(name)
-        print(len(results))
-        print('\n')
         #Use Sprinkler now
         sp = sprinkler(results, self.mjd, self.specFileMap, self.sed_dir,
                        density_param=1.0,
@@ -52,14 +45,6 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
                        sne_cache_file=self.sne_cache_file,
                        defs_file=self.defs_file)
         results = sp.sprinkle()
-
-        print('after sprinkling')
-        n_agn = len(np.where(results['agn_descqa_is_sprinkled']==1)[0])
-        n_bulge = len(np.where(results['bulge_descqa_is_sprinkled']==1)[0])
-        n_disk = len(np.where(results['disk_descqa_is_sprinkled']==1)[0])
-        print(n_agn, n_bulge, n_disk)
-        print(len(results))
-        print('\n\n\n')
 
         return results
 

--- a/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
@@ -61,19 +61,6 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
         print(len(results))
         print('\n\n\n')
 
-        # copy results from the InstanceCatalog queries
-        # into the truth_* catalog queries
-        column_name_list = results.dtype.names
-        for name in column_name_list:
-            if name.startswith('truth'):
-                continue
-            truth_name = 'truth_%s' % name
-            if truth_name not in column_name_list:
-                continue
-
-            print('copying %s from %s' % (truth_name, name))
-            results[truth_name] = results[name]
-
         return results
 
 class TwinklesCatalogSersic2D_DC2(PhoSimDESCQA):

--- a/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
@@ -54,6 +54,10 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
         results = sp.sprinkle()
 
         print('after sprinkling')
+        n_agn = len(np.where(results['agn_descqa_is_sprinkled']==1)[0])
+        n_bulge = len(np.where(results['bulge_descqa_is_sprinkled']==1)[0])
+        n_disk = len(np.where(results['disk_descqa_is_sprinkled']==1)[0])
+        print(n_agn, n_bulge, n_disk)
         print(len(results))
         print('\n\n\n')
 

--- a/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
@@ -38,7 +38,10 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
 
     def _final_pass(self, results):
         print('\n\n\nsprinkling')
-        print(results.dtype.names)
+        name_list = results.dtype.names
+        for name in name_list:
+            if 'sprinkled' in name:
+                print(name)
         print(len(results))
         print('\n')
         #Use Sprinkler now

--- a/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
@@ -37,7 +37,10 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
     agn_objid = 'agn_descqa'
 
     def _final_pass(self, results):
-        print('\n\n\nsprinkling\n\n\n')
+        print('\n\n\nsprinkling')
+        print(results.dtype.names)
+        print(len(results))
+        print('\n')
         #Use Sprinkler now
         sp = sprinkler(results, self.mjd, self.specFileMap, self.sed_dir,
                        density_param=1.0,
@@ -46,6 +49,10 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
                        sne_cache_file=self.sne_cache_file,
                        defs_file=self.defs_file)
         results = sp.sprinkle()
+
+        print('after sprinkling')
+        print(len(results))
+        print('\n\n\n')
 
         return results
 

--- a/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/TwinklesClasses.py
@@ -37,7 +37,7 @@ class sprinklerCompound_DC2(GalaxyCompoundDESCQAObject):
     agn_objid = 'agn_descqa'
 
     def _final_pass(self, results):
-
+        print('\n\n\nsprinkling\n\n\n')
         #Use Sprinkler now
         sp = sprinkler(results, self.mjd, self.specFileMap, self.sed_dir,
                        density_param=1.0,


### PR DESCRIPTION
This isn't actually a mature pull request, so much as a place where we can organize our thoughts on how to get truth information out of the sprinkler.

I have added an `is_sprinkled` column to the InstanceCatalogs.  There is a PR into the Twinkles repo which will alter the sprinkler to set `is_sprinkled=1` for any objects changed or added by the sprinkler.  I have then added code to the `InstanceCatalogWriter` so that, for each InstanceCatalog that gets written, it will write out a truth catalog with the RA, Dec, SED, magNorm, uniqueId, and galaxy_id of objects for which `is_sprinkled==1`.  These are just placeholder columns.  We will need to talk about what we want the columns to be.

Obviously, this PR will result in many truth catalogs (one per InstanceCatalog) being written.  We will have to add code elsewhere to cull these down into a single, multi-epoch truth catalog, assuming this is the strategy we want to adopt for sprinkler truth info.
