### PR TITLE
add ability to cut on structure function

### DIFF
--- a/bin.src/create_agn_db.py
+++ b/bin.src/create_agn_db.py
@@ -96,6 +96,11 @@ if __name__ == "__main__":
                         "used to introduce scatter into AGN parameter "
                         "distributions. Default=81")
 
+    parser.add_argument('--max_sf', type=float, default=4.0,
+                        help="Maximum allowed value for the structure "
+                        "function of the random walk driving AGN "
+                        "variability.  Default=4 (in magnitudes)")
+
     args = parser.parse_args()
 
     if args.out_file is None:
@@ -168,6 +173,20 @@ if __name__ == "__main__":
         sf_dict[bp] = SF_from_params(redshift, abs_mag_i,
                                      bhm, eff_wavelen,
                                      rng=rng)
+
+    # cut on structure function value
+    for bp in 'ugrizy':
+        valid = np.where(sf_dict[bp]<args.max_sf)
+        redshift = redshift[valid]
+        tau = tau[valid]
+        log_edd_ratio = log_edd_ratio[valid]
+        abs_mag_i = abs_mag_i[valid]
+        obs_mag_i = obs_mag_i[valid]
+        bhm = bhm[valid]
+        galaxy_id = galaxy_id[valid]
+        for other_bp in 'ugrizy':
+            sf_dict[other_bp] = sf_dict[other_bp][valid]
+
 
     sed_dir = os.path.join(getPackageDir('sims_sed_library'),
                            'agnSED')


### PR DESCRIPTION
when creating AGN variability model

Demanding that the structure function is <= 4.0 magnitudes reduces the number of AGN from 328,872 down to 326,505 (in both cases, the cut on black hole mass was 10**7 solar masses and the cut on m_i was 30.0)