### PR TITLE
U/danielsf/shear/convention

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -278,7 +278,7 @@ class DESCQAObject(object):
         gc.add_quantity_modifier('redshift', gc.get_quantity_modifier('redshift_true'), overwrite=True)
         gc.add_quantity_modifier('true_redshift', gc.get_quantity_modifier('redshift_true'))
         gc.add_quantity_modifier('gamma1', gc.get_quantity_modifier('shear_1'))
-        gc.add_quantity_modifier('gamma2', gc.get_quantity_modifier('shear_2'))
+        gc.add_quantity_modifier('gamma2', gc.get_quantity_modifier('shear_2_phosim'))
         gc.add_quantity_modifier('kappa', gc.get_quantity_modifier('convergence'))
 
         gc.add_modifier_on_derived_quantities('positionAngle', np.radians, 'position_angle_true')

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -338,6 +338,9 @@ class InstanceCatalogWriter(object):
                                       diskDESCQAObject,
                                       agnDESCQAObject]
 
+            for db_class in self.compoundGalDBList:
+                db_class.yaml_file_name = self.descqa_catalog
+
             gal_cat = twinklesDESCQACompoundObject(self.compoundGalICList,
                                                    self.compoundGalDBList,
                                                    obs_metadata=obs_md,


### PR DESCRIPTION
This pull request changes the interface with the shear components so that shear_2_phosim gets written to the InstanceCatalogs.

It also fixes a bug in which the user-specified descqa_catalog was not being passed to the DBObject classes used by the sprinkler.