### PR TITLE
U/danielsf/cosmodc2/healpix

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -286,8 +286,9 @@ class PhoSimDESCQA(PhoSimCatalogSersic2D, EBVmixin):
                                'Neither appear to be in self._cannot_be_null.\n'
                                'self._cannot_be_null: %s' % self._cannot_be_null)
 
-        mag_array = np.array([-2.5*np.log10(self.column_by_name(name))
-                              for name in flux_names])
+        with np.errstate(divide='ignore', invalid='ignore'):
+            mag_array = np.array([-2.5*np.log10(self.column_by_name(name))
+                                  for name in flux_names])
 
         redshift_array = self.column_by_name('true_redshift')
 

--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -316,7 +316,7 @@ class PhoSimDESCQA(PhoSimCatalogSersic2D, EBVmixin):
         return np.where(preliminary_output<998.0, preliminary_output, np.NaN)
 
     @cached
-    def get_sedFilename(self):
+    def get_sedFilepath(self):
         raw_filename = self.column_by_name('sedFilename_dc2')
         fitted_filename = self.column_by_name('sedFilename_fitted')
         return np.where(np.char.find(raw_filename.astype('str'), 'None')==0,

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -113,18 +113,10 @@ class DESCQAChunkIterator(object):
                              if descqa_catalog.has_quantity(self._column_map[name][0])]
 
             self._loaded_qties = {}
-            n_names = len(qty_name_list)
-            d_name = 10
-            for first_name in range(0, n_names, d_name):
-                last_name = first_name + d_name
-                if n_names-last_name < d_name:
-                    last_name = n_names
-
-                raw_qties = descqa_catalog.get_quantities(qty_name_list[first_name:last_name],
+            for name in qty_name_list:
+                raw_qties = descqa_catalog.get_quantities(name,
                                                           native_filters=native_filters)
-
-                for name in raw_qties.keys():
-                    self._loaded_qties[name] = raw_qties[name][self._data_indices]
+                self._loaded_qties[name] = raw_qties[name][self._data_indices]
 
             print('loaded all quantities')
             # since we are only keeping the objects that will ultimately go into

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -110,10 +110,19 @@ class DESCQAChunkIterator(object):
                              for name in self._colnames
                              if descqa_catalog.has_quantity(self._column_map[name][0])]
 
-            self._loaded_qties = {name:
-                                  descqa_catalog.get_quantities([name],
-                                        native_filters=native_filters)[name][self._data_indices]
-                                  for name in qty_name_list}
+            self._loaded_qties = {}
+            n_names = len(qty_name_list)
+            d_name = 10
+            for first_name in range(0, n_names, d_name):
+                last_name = first_name + d_name
+                if n_names-last_name < d_name:
+                    last_name = n_names
+
+                raw_qties = descqa_catalog.get_quantities(qty_name_list[first_name:last_name],
+                                                          native_filters=native_filters)
+
+                for name in raw_qties.keys():
+                    self._loaded_qties[name] = raw_qties[name][self._data_indices]
 
             # since we are only keeping the objects that will ultimately go into
             # the catalog, we now change self._data_indices to range from 0

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -142,8 +142,8 @@ class DESCQAChunkIterator(object):
         # temporarily suppress divide by zero warnings
         with np.errstate(divide='ignore', invalid='ignore'):
             chunk = dict_to_numpy_array({name: self._loaded_qties[self._column_map[name][0]][data_indices_this]
-                                        for name in self._colnames
-                                        if descqa_catalog.has_quantity(self._column_map[name][0])})
+                                         for name in self._colnames
+                                         if descqa_catalog.has_quantity(self._column_map[name][0])})
 
         need_to_append_defaults = False
         for name in self._colnames:

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -126,6 +126,7 @@ class DESCQAChunkIterator(object):
                 for name in raw_qties.keys():
                     self._loaded_qties[name] = raw_qties[name][self._data_indices]
 
+            print('loaded all quantities')
             # since we are only keeping the objects that will ultimately go into
             # the catalog, we now change self._data_indices to range from 0
             # to the length of the final catalog; the indices relative to the
@@ -208,6 +209,7 @@ class DESCQAChunkIterator(object):
                                                  inclusive=True,
                                                  nest=False)
 
+                print('healpix list ',healpix_list)
                 healpix_filter = GCRQuery('healpix_pixel==%d' % healpix_list[0])
                 for hh in healpix_list[1:]:
                     healpix_filter = healpix_filter | GCRQuery('healpix_pixel==%d' % hh)

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -198,14 +198,19 @@ class DESCQAChunkIterator(object):
                                                  inclusive=True,
                                                  nest=False)
 
-                healpix_filter = GCRQuery('healpix_pixel==%d' % healpix_list[0])
-                for hh in healpix_list[1:]:
-                    healpix_filter = healpix_filter | GCRQuery('healpix_pixel==%d' % hh)
+                healpix_filter = None
+                for hh in healpix_list:
+                    local_filter = GCRQuery('healpix_pixel==%d' % hh)
+                    if healpix_filter is None:
+                        healpix_filter = local_filter
+                    else:
+                        healpix_filter |= local_filter
 
-                if self._native_filters is None:
-                    self._native_filters = [healpix_filter]
-                else:
-                    self._native_filters.append(healpix_filter)
+                if healpix_filter is not None:
+                    if self._native_filters is None:
+                        self._native_filters = [healpix_filter]
+                    else:
+                        self._native_filters.append(healpix_filter)
 
             ra_dec = descqa_catalog.get_quantities(['raJ2000', 'decJ2000'],
                                                    native_filters=self._native_filters)

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -118,7 +118,6 @@ class DESCQAChunkIterator(object):
                                                           native_filters=native_filters)
                 self._loaded_qties[name] = raw_qties[name][self._data_indices]
 
-            print('loaded all quantities')
             # since we are only keeping the objects that will ultimately go into
             # the catalog, we now change self._data_indices to range from 0
             # to the length of the final catalog; the indices relative to the
@@ -131,11 +130,6 @@ class DESCQAChunkIterator(object):
             self._loaded_qties = None
             self._data_indices = None
             raise StopIteration
-
-        print('    chunk %d %d %d' %
-        (data_indices_this[0],
-         data_indices_this[-1],
-         self._data_indices[-1]))
 
         self._data_indices = self._data_indices[self._chunk_size:]
 

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -189,7 +189,7 @@ class DESCQAChunkIterator(object):
             except (TypeError, IndexError):
                 radius_rad = self._obs_metadata._boundLength
 
-            if 'healpix_pixels' in dir(descqa_catalog):
+            if 'healpix_pixel' in descqa_catalog._native_filter_quantities:
                 ra_rad = self._obs_metadata._pointingRA
                 dec_rad = self._obs_metadata._pointingDec
                 vv = np.array([np.cos(dec_rad)*np.cos(ra_rad),

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -190,7 +190,6 @@ class DESCQAChunkIterator(object):
                 radius_rad = self._obs_metadata._boundLength
 
             if 'healpix_pixels' in dir(descqa_catalog):
-                print('filtering on healpixel')
                 ra_rad = self._obs_metadata._pointingRA
                 dec_rad = self._obs_metadata._pointingDec
                 vv = np.array([np.cos(dec_rad)*np.cos(ra_rad),
@@ -200,7 +199,6 @@ class DESCQAChunkIterator(object):
                                                  inclusive=True,
                                                  nest=False)
 
-                print('healpix list ',healpix_list)
                 healpix_filter = GCRQuery('healpix_pixel==%d' % healpix_list[0])
                 for hh in healpix_list[1:]:
                     healpix_filter = healpix_filter | GCRQuery('healpix_pixel==%d' % hh)

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -140,6 +140,11 @@ class DESCQAChunkIterator(object):
             self._data_indices = None
             raise StopIteration
 
+        print('    chunk %d %d %d' %
+        (data_indices_this[0],
+         data_indices_this[-1],
+         self._data_indices[-1]))
+
         self._data_indices = self._data_indices[self._chunk_size:]
 
         # temporarily suppress divide by zero warnings

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -110,11 +110,10 @@ class DESCQAChunkIterator(object):
                              for name in self._colnames
                              if descqa_catalog.has_quantity(self._column_map[name][0])]
 
-            self._loaded_qties = descqa_catalog.get_quantities(qty_name_list,
-                                                               native_filters=native_filters)
-
-            for name in qty_name_list:
-                self._loaded_qties[name] = self._loaded_qties[name][self._data_indices]
+            self._loaded_qties = {name:
+                                  descqa_catalog.get_quantities([name],
+                                        native_filters=native_filters)[name][self._data_indices]
+                                  for name in qty_name_list}
 
             # since we are only keeping the objects that will ultimately go into
             # the catalog, we now change self._data_indices to range from 0

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -309,8 +309,8 @@ class DESCQAObject(object):
 
         gc is a GCR catalog instance
         """
-        gc.add_modifier_on_derived_quantities('raJ2000', deg2rad_double, 'ra_true')
-        gc.add_modifier_on_derived_quantities('decJ2000', deg2rad_double, 'dec_true')
+        gc.add_derived_quantity('raJ2000', deg2rad_double, 'ra_true')
+        gc.add_derived_quantity('decJ2000', deg2rad_double, 'dec_true')
 
     def _transform_catalog(self, gc):
         """
@@ -339,12 +339,12 @@ class DESCQAObject(object):
         gc.add_quantity_modifier('gamma2', gc.get_quantity_modifier('shear_2_phosim'))
         gc.add_quantity_modifier('kappa', gc.get_quantity_modifier('convergence'))
 
-        gc.add_modifier_on_derived_quantities('positionAngle', np.radians, 'position_angle_true')
+        gc.add_derived_quantity('positionAngle', np.radians, 'position_angle_true')
 
-        gc.add_modifier_on_derived_quantities('majorAxis::disk', arcsec2rad, 'size_disk_true')
-        gc.add_modifier_on_derived_quantities('minorAxis::disk', arcsec2rad, 'size_minor_disk_true')
-        gc.add_modifier_on_derived_quantities('majorAxis::bulge', arcsec2rad, 'size_bulge_true')
-        gc.add_modifier_on_derived_quantities('minorAxis::bulge', arcsec2rad, 'size_minor_bulge_true')
+        gc.add_derived_quantity('majorAxis::disk', arcsec2rad, 'size_disk_true')
+        gc.add_derived_quantity('minorAxis::disk', arcsec2rad, 'size_minor_disk_true')
+        gc.add_derived_quantity('majorAxis::bulge', arcsec2rad, 'size_bulge_true')
+        gc.add_derived_quantity('minorAxis::bulge', arcsec2rad, 'size_minor_bulge_true')
 
         gc.add_quantity_modifier('sindex::disk', gc.get_quantity_modifier('sersic_disk'))
         gc.add_quantity_modifier('sindex::bulge', gc.get_quantity_modifier('sersic_bulge'))
@@ -375,9 +375,9 @@ class DESCQAObject(object):
         """
         # Hacky solution, the number of knots replaces the sersic index,
         # keeping the rest of the sersic parameters, which are directly applicable
-        gc.add_modifier_on_derived_quantities('sindex::knots', lambda x:x, 'n_knots')
-        gc.add_modifier_on_derived_quantities('majorAxis::knots', arcsec2rad, 'size_disk_true')
-        gc.add_modifier_on_derived_quantities('minorAxis::knots', arcsec2rad, 'size_minor_disk_true')
+        gc.add_derived_quantity('sindex::knots', lambda x:x, 'n_knots')
+        gc.add_derived_quantity('majorAxis::knots', arcsec2rad, 'size_disk_true')
+        gc.add_derived_quantity('minorAxis::knots', arcsec2rad, 'size_minor_disk_true')
 
         # Apply flux correction for the random walk
         add_postfix = []
@@ -386,8 +386,8 @@ class DESCQAObject(object):
                 # The epsilon value is to keep the disk component, so that
                 # the random sequence in extinction parameters is preserved
                 eps = np.finfo(np.float32).eps
-                gc.add_modifier_on_derived_quantities(name+'::disk', lambda x,y: x*np.clip(1-y, eps, None), name, 'knots_flux_ratio')
-                gc.add_modifier_on_derived_quantities(name+'::knots', lambda x,y: x*np.clip(y, eps,None), name, 'knots_flux_ratio')
+                gc.add_derived_quantity(name+'::disk', lambda x,y: x*np.clip(1-y, eps, None), name, 'knots_flux_ratio')
+                gc.add_derived_quantity(name+'::knots', lambda x,y: x*np.clip(y, eps,None), name, 'knots_flux_ratio')
                 add_postfix.append(name)
 
         # Returning these columns so that they can be registered for postfix filtering

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -295,6 +295,7 @@ class InstanceCatalogWriter(object):
             cat.photParams = self.phot_params
             cat.lsstBandpassDict = self.bp_dict
             written_catalog_names.append(cat_name)
+            print('wrote disks')
 
             agn_db = agnDESCQAObject(self.descqa_catalog)
             agn_db.field_ra = self.protoDC2_ra

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -283,6 +283,7 @@ class InstanceCatalogWriter(object):
             cat.lsstBandpassDict = self.bp_dict
             written_catalog_names.append(cat_name)
             print('wrote bulges')
+            exit()
 
             disk_db = diskDESCQAObject(self.descqa_catalog)
             disk_db.field_ra = self.protoDC2_ra

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -282,7 +282,6 @@ class InstanceCatalogWriter(object):
             cat.photParams = self.phot_params
             cat.lsstBandpassDict = self.bp_dict
             written_catalog_names.append(cat_name)
-            print('wrote bulges')
 
             disk_db = diskDESCQAObject(self.descqa_catalog)
             disk_db.field_ra = self.protoDC2_ra
@@ -295,7 +294,6 @@ class InstanceCatalogWriter(object):
             cat.photParams = self.phot_params
             cat.lsstBandpassDict = self.bp_dict
             written_catalog_names.append(cat_name)
-            print('wrote disks')
 
             agn_db = agnDESCQAObject(self.descqa_catalog)
             agn_db.field_ra = self.protoDC2_ra

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -283,7 +283,6 @@ class InstanceCatalogWriter(object):
             cat.lsstBandpassDict = self.bp_dict
             written_catalog_names.append(cat_name)
             print('wrote bulges')
-            exit()
 
             disk_db = diskDESCQAObject(self.descqa_catalog)
             disk_db.field_ra = self.protoDC2_ra

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -282,6 +282,8 @@ class InstanceCatalogWriter(object):
             cat.photParams = self.phot_params
             cat.lsstBandpassDict = self.bp_dict
             written_catalog_names.append(cat_name)
+            print('wrote bulges')
+            exit()
 
             disk_db = diskDESCQAObject(self.descqa_catalog)
             disk_db.field_ra = self.protoDC2_ra

--- a/python/desc/sims/GCRCatSimInterface/SedFitter.py
+++ b/python/desc/sims/GCRCatSimInterface/SedFitter.py
@@ -195,7 +195,9 @@ def sed_from_galacticus_mags(galacticus_mags, redshift, H0, Om0,
     def _find_closest_sed(colors_this):
         return np.argmin(np.sum((sed_from_galacticus_mags._sed_colors - colors_this)**2, axis=1))
 
-    galacticus_colors = galacticus_mags_t[:,1:] - galacticus_mags_t[:,:-1] # N_star by (N_mag - 1)
+    with np.errstate(invalid='ignore', divide='ignore'):
+        galacticus_colors = galacticus_mags_t[:,1:] - galacticus_mags_t[:,:-1] # N_star by (N_mag - 1)
+
     sed_idx = np.fromiter(
         (_find_closest_sed(colors_this) for colors_this in galacticus_colors),
         np.int,

--- a/python/desc/sims/GCRCatSimInterface/SedFitter.py
+++ b/python/desc/sims/GCRCatSimInterface/SedFitter.py
@@ -4,6 +4,7 @@ import numpy as np
 import GCRCatalogs
 import scipy.spatial as scipy_spatial
 from lsst.utils import getPackageDir
+from lsst.sims.utils import defaultSpecMap
 from lsst.sims.photUtils import BandpassDict, Bandpass, Sed, CosmologyObject
 
 __all__ = ["sed_filter_names_from_catalog", "sed_from_galacticus_mags"]
@@ -128,7 +129,7 @@ def _create_sed_library_mags(wav_min, wav_width):
     for sed_file_name in os.listdir(_galaxy_sed_dir):
         spec = Sed()
         spec.readSED_flambda(os.path.join(_galaxy_sed_dir, sed_file_name))
-        sed_names.append(sed_file_name)
+        sed_names.append(defaultSpecMap[sed_file_name])
         sed_mag_list.append(tuple(bandpass_dict.magListForSed(spec)))
         sed_mag_norm.append(spec.calcMag(imsim_bp))
 


### PR DESCRIPTION
This PR speeds up InstanceCatalog generation so that it is feasible to run on CosmoDC2.  Specifically, speed-ups were achieved by

- applying a native_filter on healpixel ID
- only loading each cosmoDC2 quantity once, and holding all required values in memory
- using scipy.spatial.cKDTree to do the nearest neighbor search in SED assignment

With these optimization, a single LSST field of view (radius=2 degrees) was generated in ~ 70 minutes with a maximum memory footprint on Cori's login node of 20GB.  This test did not use the sprinkler.