### PR TITLE
Updates the knots production code to be compatible with recent GCR version

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -5,6 +5,7 @@ __all__ = ["DESCQAObject", "bulgeDESCQAObject", "diskDESCQAObject", "knotsDESCQA
            "deg2rad_double", "arcsec2rad", "SNFileDBObject"]
 
 import numpy as np
+import re
 import healpy
 from lsst.sims.catalogs.db import fileDBObject
 
@@ -375,10 +376,12 @@ class DESCQAObject(object):
 
         # Apply flux correction for the random walk
         add_postfix = []
+        disk_re = re.compile(r'sed_(\d+)_(\d+)_disk_no_host_extinction$')
         for name in gc.list_all_native_quantities():
             # To account for the new composite catalog API,where name is a tuple
             parent, name = name
-            if 'SEDs/diskLuminositiesStellar:SED' in name:
+            disk_match = disk_re.match(name)
+            if disk_match is not None:
                 # The epsilon value is to keep the disk component, so that
                 # the random sequence in extinction parameters is preserved
                 eps = np.finfo(np.float32).eps

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -282,7 +282,7 @@ class DESCQAObject(object):
 
         if self._columns_need_postfix:
             self._columns_need_postfix += _ADDITIONAL_POSTFIX_CACHE[yaml_file_name + self._cat_cache_suffix]
-        else:
+        elif self._postfix:
             self._columns_need_postfix = _ADDITIONAL_POSTFIX_CACHE[yaml_file_name + self._cat_cache_suffix]
 
         self._catalog_id = yaml_file_name + self._cat_cache_suffix

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -16,14 +16,6 @@ try:
 except ImportError:
     _GCR_IS_AVAILABLE = False
 
-
-_ALPHA_Q_ADD_ON_IS_AVAILABLE = True
-try:
-    from GCRCatalogs.alphaq_addon import AlphaQAddonCatalog
-except ImportError:
-    _ALPHA_Q_ADD_ON_IS_AVAILABLE = False
-
-
 _LSST_IS_AVAILABLE = True
 try:
     from lsst.sims.utils import _angularSeparation
@@ -32,7 +24,6 @@ except ImportError:
     from astropy.coordinates import SkyCoord
     def _angularSeparation(ra1, dec1, ra2, dec2):
         return SkyCoord(ra1, dec1, unit="radian").separation(SkyCoord(ra2, dec2, unit="radian")).radian
-
 
 def deg2rad_double(x):
     return np.deg2rad(x).astype(np.float64)
@@ -352,8 +343,11 @@ class DESCQAObject(object):
         additional_postfix = ()
 
         # Test for random walk specific addon
-        if _ALPHA_Q_ADD_ON_IS_AVAILABLE:
-            if isinstance(gc, AlphaQAddonCatalog):
+        # This gets activated only if the catalog is a composite, and only if one
+        # of the composite catalogs is a knots catalog
+        cat_info = gc.get_catalog_info()
+        if cat_info['subclass_name'] == composite.CompositeReader:
+            if 'knots' in [c['catalog_name'] for c in cat_info['catalogs']]:
                 additional_postfix += self._transform_knots(gc)
 
         return additional_postfix

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -346,7 +346,7 @@ class DESCQAObject(object):
         # This gets activated only if the catalog is a composite, and only if one
         # of the composite catalogs is a knots catalog
         cat_info = gc.get_catalog_info()
-        if cat_info['subclass_name'] == composite.CompositeReader:
+        if cat_info['subclass_name'] == 'composite.CompositeReader':
             if 'knots' in [c['catalog_name'] for c in cat_info['catalogs']]:
                 additional_postfix += self._transform_knots(gc)
 

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -8,6 +8,7 @@ import numpy as np
 import re
 import healpy
 from lsst.sims.catalogs.db import fileDBObject
+from .SedFitter import disk_re
 
 _GCR_IS_AVAILABLE = True
 try:
@@ -376,7 +377,7 @@ class DESCQAObject(object):
 
         # Apply flux correction for the random walk
         add_postfix = []
-        disk_re = re.compile(r'sed_(\d+)_(\d+)_disk_no_host_extinction$')
+        
         for name in gc.list_all_native_quantities():
             # To account for the new composite catalog API,where name is a tuple
             parent, name = name

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -5,7 +5,6 @@ __all__ = ["DESCQAObject", "bulgeDESCQAObject", "diskDESCQAObject", "knotsDESCQA
            "deg2rad_double", "arcsec2rad", "SNFileDBObject"]
 
 import numpy as np
-import re
 import healpy
 from lsst.sims.catalogs.db import fileDBObject
 from .SedFitter import disk_re
@@ -348,9 +347,9 @@ class DESCQAObject(object):
         # This gets activated only if the catalog is a composite, and only if one
         # of the composite catalogs is a knots catalog
         cat_info = gc.get_catalog_info()
-        if cat_info['subclass_name'] == 'composite.CompositeReader':
-            if 'knots' in [c['catalog_name'] for c in cat_info['catalogs']]:
-                additional_postfix += self._transform_knots(gc)
+        if (cat_info.get('subclass_name') == 'composite.CompositeReader'
+            and any('knots' in c.get('catalog_name', '') for c in cat_info.get('catalogs', []))):
+            additional_postfix += self._transform_knots(gc)
 
         return additional_postfix
 
@@ -377,8 +376,8 @@ class DESCQAObject(object):
 
         # Apply flux correction for the random walk
         add_postfix = []
-        
-        for name in gc.list_all_native_quantities():
+
+        for name in gc.list_all_quantities(include_native=True):
             # To account for the new composite catalog API,where name is a tuple
             parent, name = name
             disk_match = disk_re.match(name)

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -376,6 +376,8 @@ class DESCQAObject(object):
         # Apply flux correction for the random walk
         add_postfix = []
         for name in gc.list_all_native_quantities():
+            # To account for the new composite catalog API,where name is a tuple
+            parent, name = name
             if 'SEDs/diskLuminositiesStellar:SED' in name:
                 # The epsilon value is to keep the disk component, so that
                 # the random sequence in extinction parameters is preserved

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -199,7 +199,7 @@ class InstanceCatalogWriter(object):
             if os.path.exists(host_data_dir):
                 self.host_data_dir = host_data_dir
             else:
-                raise IOError("Path to host data directory does not exist.")    
+                raise IOError("Path to host data directory does not exist.")
 
         self.instcats = get_instance_catalogs()
 
@@ -274,7 +274,6 @@ class InstanceCatalogWriter(object):
         parallelCatalogWriter(cat_dict, chunk_size=100000, write_header=False)
         written_catalog_names.append(star_name)
 
-        # TODO: Find a better way of checking for catalog type
         if 'knots' in self.descqa_catalog:
             knots_db =  knotsDESCQAObject(self.descqa_catalog)
             knots_db.field_ra = self.protoDC2_ra

--- a/python/desc/sims/GCRCatSimInterface/SedFitter.py
+++ b/python/desc/sims/GCRCatSimInterface/SedFitter.py
@@ -7,10 +7,12 @@ from lsst.utils import getPackageDir
 from lsst.sims.utils import defaultSpecMap
 from lsst.sims.photUtils import BandpassDict, Bandpass, Sed, CosmologyObject
 
-__all__ = ["sed_filter_names_from_catalog", "sed_from_galacticus_mags"]
+__all__ = ["disk_re", "bulge_re", "sed_filter_names_from_catalog", "sed_from_galacticus_mags"]
 
 _galaxy_sed_dir = os.path.join(getPackageDir('sims_sed_library'), 'galaxySED')
 
+disk_re = re.compile(r'sed_(\d+)_(\d+)_disk_no_host_extinction$')
+bulge_re = re.compile(r'sed_(\d+)_(\d+)_bulge_no_host_extinction$')
 
 def sed_filter_names_from_catalog(catalog):
     """
@@ -33,9 +35,6 @@ def sed_filter_names_from_catalog(catalog):
 
     All outputs will be returned in order of increasing wav_min
     """
-
-    disk_re = re.compile(r'sed_(\d+)_(\d+)_disk_no_host_extinction$')
-    bulge_re = re.compile(r'sed_(\d+)_(\d+)_bulge_no_host_extinction$')
 
     all_quantities = catalog.list_all_quantities()
 


### PR DESCRIPTION
Due to a number of updates of the GCR in recent months, the code for producing the knots didn't work anymore. This PR repairs the pieces that were out of date and sims_GCRCatSimInterface can produce instance catalogs with knots again.

Note that this doesn't touch interactions with the sprinkler, that's a different issue (it doesn't work yet...).