### PR TITLE
Minor fix that prevents annoying crashes when the  sprinkler is disabled

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -187,7 +187,7 @@ class InstanceCatalogWriter(object):
 
         if host_image_dir is None and self.sprinkler is not False:
             raise IOError("Need to specify the name of the host image directory.")
-        elif self.sprinkler:
+        elif self.sprinkler is not False:
             if os.path.exists(host_image_dir):
                 self.host_image_dir = host_image_dir
             else:
@@ -195,7 +195,7 @@ class InstanceCatalogWriter(object):
 
         if host_data_dir is None and self.sprinkler is not False:
             raise IOError("Need to specify the name of the host data directory.")
-        elif self.sprinkler:
+        elif self.sprinkler is not False:
             if os.path.exists(host_data_dir):
                 self.host_data_dir = host_data_dir
             else:

--- a/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
+++ b/python/desc/sims/GCRCatSimInterface/InstanceCatalogWriter.py
@@ -187,7 +187,7 @@ class InstanceCatalogWriter(object):
 
         if host_image_dir is None and self.sprinkler is not False:
             raise IOError("Need to specify the name of the host image directory.")
-        else:
+        elif self.sprinkler:
             if os.path.exists(host_image_dir):
                 self.host_image_dir = host_image_dir
             else:
@@ -195,7 +195,7 @@ class InstanceCatalogWriter(object):
 
         if host_data_dir is None and self.sprinkler is not False:
             raise IOError("Need to specify the name of the host data directory.")
-        else:
+        elif self.sprinkler:
             if os.path.exists(host_data_dir):
                 self.host_data_dir = host_data_dir
             else:


### PR DESCRIPTION
In the current code, when the sprinkler is disabled, the `generateInstCat.py` will crash if the path to `SIMS_GCRCATSIMINTERFACE_DIR/data/outputs` doesn't exist, which shouldn't be a problem given that the sprinkler is disabled. This PR just fixes the path verification logic and ignores the missing path in case the sprinkler is disabled