### PR TITLE
Homogenizes the GCR SED extraction between SEDFitter and DatabaseEmulator

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -377,9 +377,7 @@ class DESCQAObject(object):
         # Apply flux correction for the random walk
         add_postfix = []
 
-        for name in gc.list_all_quantities(include_native=True):
-            # To account for the new composite catalog API,where name is a tuple
-            parent, name = name
+        for name in gc.list_all_quantities():
             disk_match = disk_re.match(name)
             if disk_match is not None:
                 # The epsilon value is to keep the disk component, so that


### PR DESCRIPTION
In the case of a composite catalog, `gc.list_all_quantities(include_native=True)` returns a list of tuples or simple string, in the latter case the loop over quantities affected by this  PR would fail. So here is a small fix that simply reuses the same code as in SEDFitter.py