### PR TITLE
Disable knots below a given magnitude cuts

### DIFF
--- a/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
+++ b/python/desc/sims/GCRCatSimInterface/CatalogClasses.py
@@ -197,7 +197,9 @@ class PhoSimDESCQA(PhoSimCatalogSersic2D, EBVmixin):
     # below are defined getter methods used to define CatSim value-added columns
     @cached
     def get_hasDisk(self):
-        output = np.where(self.column_by_name('stellar_mass_disk')>0.0, 1.0, None)
+        output = np.where(np.logical_and(self.column_by_name('stellar_mass_disk')>0.0,
+                                         np.isfinite(self.column_by_name('A_v_disk').astype(float))),
+                          1.0, None)
         return output
 
     @cached

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -34,6 +34,8 @@ def deg2rad_double(x):
 def arcsec2rad(x):
     return np.deg2rad(x/3600.0)
 
+# The depth below which to ignore the knots
+KNOTS_IMAG_CUT = 27
 
 # a cache to store loaded catalogs to prevent them
 # from being loaded more than once, eating up
@@ -385,8 +387,8 @@ class DESCQAObject(object):
                 # The epsilon value is to keep the disk component, so that
                 # the random sequence in extinction parameters is preserved
                 eps = np.finfo(np.float32).eps
-                gc.add_derived_quantity(name+'::disk', lambda x,y: x*np.clip(1-y, eps, None), name, 'knots_flux_ratio')
-                gc.add_derived_quantity(name+'::knots', lambda x,y: x*np.clip(y, eps,None), name, 'knots_flux_ratio')
+                gc.add_derived_quantity(name+'::disk', lambda x,y,imag:  (imag < KNOTS_IMAG_CUT) * x*np.clip(1-y, eps, None) + (imag > KNOTS_IMAG_CUT)*x, name, 'knots_flux_ratio', 'mag_i_lsst')
+                gc.add_derived_quantity(name+'::knots', lambda x,y,imag: (imag < KNOTS_IMAG_CUT) * x*np.clip(y, eps,None)  , name, 'knots_flux_ratio', 'mag_i_lsst')
                 add_postfix.append(name)
 
         # Returning these columns so that they can be registered for postfix filtering

--- a/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
+++ b/python/desc/sims/GCRCatSimInterface/DatabaseEmulator.py
@@ -387,8 +387,8 @@ class DESCQAObject(object):
                 # The epsilon value is to keep the disk component, so that
                 # the random sequence in extinction parameters is preserved
                 eps = np.finfo(np.float32).eps
-                gc.add_derived_quantity(name+'::disk', lambda x,y,imag:  (imag < KNOTS_IMAG_CUT) * x*np.clip(1-y, eps, None) + (imag > KNOTS_IMAG_CUT)*x, name, 'knots_flux_ratio', 'mag_i_lsst')
-                gc.add_derived_quantity(name+'::knots', lambda x,y,imag: (imag < KNOTS_IMAG_CUT) * x*np.clip(y, eps,None)  , name, 'knots_flux_ratio', 'mag_i_lsst')
+                gc.add_derived_quantity(name+'::disk', lambda x,y,imag:  (imag <= KNOTS_IMAG_CUT) * x*np.clip(1-y, eps, None) + (imag > KNOTS_IMAG_CUT)*x, name, 'knots_flux_ratio', 'mag_i_lsst')
+                gc.add_derived_quantity(name+'::knots', lambda x,y,imag: (imag <= KNOTS_IMAG_CUT) * x*np.clip(y, eps,None)  , name, 'knots_flux_ratio', 'mag_i_lsst')
                 add_postfix.append(name)
 
         # Returning these columns so that they can be registered for postfix filtering


### PR DESCRIPTION
@danielsf @jchiang87  I have implemented a quick and dirty fix, I'm running out of time to refine it. Basically, it will not modify the flux of the disks if the galaxy is faint enough, and set 0 flux to the knots. I hope ImSim will be able to simply discard these 0 flux entries. 
@danielsf Do you think this will work ok ? Also, I would need you advice on the best way to pass the magnitude limit to the code, right now it's hardcoded.

This hasn't be tested yet!