### PR TITLE
Assigning filter-dependent tau for AGN variability

### DIFF
--- a/bin.src/create_agn_db.py
+++ b/bin.src/create_agn_db.py
@@ -307,7 +307,7 @@ if __name__ == "__main__":
                              tau_dict['y'])
 
             vals = []
-            for gal_id_i, htmid_i, mag_norm_i, seed_arr_i, 
+            for (gal_id_i, htmid_i, mag_norm_i, seed_arr_i, 
                 sf_u, 
                 sf_g, 
                 sf_r, 
@@ -319,7 +319,7 @@ if __name__ == "__main__":
                 tau_r, 
                 tau_i, 
                 tau_z, 
-                tau_y in row_by_row:
+                tau_y) in row_by_row:
                 vals.append((int(gal_id_i), int(htmid_i), mag_norm_i,
                              varParamStr_format % (seed_arr_i,
                                                    sf_u, 
@@ -336,8 +336,8 @@ if __name__ == "__main__":
                                                    tau_y)
                              ))
 
-                cursor.executemany('INSERT INTO agn_params VALUES(?, ?, ?, ?)', vals)
-                connection.commit()
+            cursor.executemany('INSERT INTO agn_params VALUES(?, ?, ?, ?)', vals)
+            connection.commit()
 
         assert ct_simulated == full_size
 

--- a/python/desc/sims/GCRCatSimInterface/AGNModule.py
+++ b/python/desc/sims/GCRCatSimInterface/AGNModule.py
@@ -213,25 +213,24 @@ def tau_from_params(redshift, M_i, mbh, eff_wavelen, rng=None):
     #    eff_wav_nm = bp_dict['i'].calcEffWavelen()
     #    tau_from_params._eff_wavelen_i = 10.0*eff_wav_nm[0]  # use phi; not sb
 
-    AA = 2.3
+    AA = 2.4
     BB = 0.17
-    CC = 0.01
-    DD = 0.12
+    CC = 0.03
+    DD = 0.21
 
     if rng is not None:
         if isinstance(redshift, numbers.Number):
             n_obj = 1
         else:
             n_obj = len(redshift)
-        AA += rng.normal(0.0, 0.1, size=n_obj)
+        AA += rng.normal(0.0, 0.2, size=n_obj)
         BB += rng.normal(0.0, 0.02, size=n_obj)
-        CC += rng.normal(0.0, 0.03, size=n_obj)
-        DD += rng.normal(0.0, 0.04, size=n_obj)
+        CC += rng.normal(0.0, 0.04, size=n_obj)
+        DD += rng.normal(0.0, 0.07, size=n_obj)
 
-    # in Angstroms for i-band
     eff_wavelen_rest = eff_wavelen/(1.0+redshift)
 
-    log_tau = AA + BB*np.log10(eff_wavelen/4000.0)
+    log_tau = AA + BB*np.log10(eff_wavelen_rest/4000.0)
     log_tau += CC*(M_i+23.0) + DD*(np.log10(mbh)-9.0)
     return np.power(10.0, log_tau)
 
@@ -262,20 +261,20 @@ def SF_from_params(redshift, M_i, mbh, eff_wavelen, rng=None):
     SF -- the structure function of the light curve at infinite
     time lag of at the effective wavelength specified
     """
-    AA = -0.56
+    AA = -0.51
     BB = -0.479
-    CC = 0.111
-    DD = 0.11
+    CC = 0.131
+    DD = 0.18
 
     if rng is not None:
         if isinstance(redshift, numbers.Number):
             n_obj = 1
         else:
             n_obj = len(redshift)
-        AA += rng.normal(0.0, 0.01, size=n_obj)
+        AA += rng.normal(0.0, 0.02, size=n_obj)
         BB += rng.normal(0.0, 0.005, size=n_obj)
-        CC += rng.normal(0.0, 0.005, size=n_obj)
-        DD += rng.normal(0.0, 0.02, size=n_obj)
+        CC += rng.normal(0.0, 0.008, size=n_obj)
+        DD += rng.normal(0.0, 0.03, size=n_obj)
 
     eff_wavelen_rest = eff_wavelen/(1.0+redshift)
 

--- a/python/desc/sims/GCRCatSimInterface/AGNModule.py
+++ b/python/desc/sims/GCRCatSimInterface/AGNModule.py
@@ -184,7 +184,7 @@ def k_correction(sed_obj, bp, redshift):
     return -2.5*np.log10((1.0+redshift)*observer_integral/restframe_integral)
 
 
-def tau_from_params(redshift, M_i, mbh, rng=None):
+def tau_from_params(redshift, M_i, mbh, eff_wavelen, rng=None):
     """
     Use equation (7) and Table 1 (7th row) of MacLeod et al.
     to get tau from black hole parameters
@@ -208,10 +208,10 @@ def tau_from_params(redshift, M_i, mbh, rng=None):
     in the i-band in days
     """
 
-    if not hasattr(tau_from_params, '_eff_wavelen_i'):
-        bp_dict = BandpassDict.loadTotalBandpassesFromFiles()
-        eff_wav_nm = bp_dict['i'].calcEffWavelen()
-        tau_from_params._eff_wavelen_i = 10.0*eff_wav_nm[0]  # use phi; not sb
+    #if not hasattr(tau_from_params, '_eff_wavelen_i'):
+    #    bp_dict = BandpassDict.loadTotalBandpassesFromFiles()
+    #    eff_wav_nm = bp_dict['i'].calcEffWavelen()
+    #    tau_from_params._eff_wavelen_i = 10.0*eff_wav_nm[0]  # use phi; not sb
 
     AA = 2.3
     BB = 0.17
@@ -229,7 +229,7 @@ def tau_from_params(redshift, M_i, mbh, rng=None):
         DD += rng.normal(0.0, 0.04, size=n_obj)
 
     # in Angstroms for i-band
-    eff_wavelen = tau_from_params._eff_wavelen_i/(1.0+redshift)
+    eff_wavelen_rest = eff_wavelen/(1.0+redshift)
 
     log_tau = AA + BB*np.log10(eff_wavelen/4000.0)
     log_tau += CC*(M_i+23.0) + DD*(np.log10(mbh)-9.0)

--- a/python/desc/sims/GCRCatSimInterface/AGNModule.py
+++ b/python/desc/sims/GCRCatSimInterface/AGNModule.py
@@ -186,7 +186,7 @@ def k_correction(sed_obj, bp, redshift):
 
 def tau_from_params(redshift, M_i, mbh, eff_wavelen, rng=None):
     """
-    Use equation (7) and Table 1 (7th row) of MacLeod et al.
+    Use equation (7) and Table 1 (last row) of MacLeod et al.
     to get tau from black hole parameters
 
     Parameters
@@ -197,6 +197,9 @@ def tau_from_params(redshift, M_i, mbh, eff_wavelen, rng=None):
     M_i is the absolute magnitude of the AGN in the i-band
 
     mbh is the mass of the blackhole in solar masses
+
+    eff_wavelen is the observer-frame effective
+    wavelength of the band in Angstroms
 
     rng is an option np.random.RandomState instantiation
     which will introduce scatter into the coefficients
@@ -237,7 +240,7 @@ def tau_from_params(redshift, M_i, mbh, eff_wavelen, rng=None):
 
 def SF_from_params(redshift, M_i, mbh, eff_wavelen, rng=None):
     """
-    Use equation (7) and Table 1 (2nd row) of MacLeod et al.
+    Use equation (7) and Table 1 (5th row) of MacLeod et al.
     to get the structure function from black hole parameters
 
     Parameters


### PR DESCRIPTION
Based on the slides I presented on the run 2.2i DDF AGN variability in the SSim telecon on 11/14, it seems that assuming a filter-independent tau (the damping timescale parameter) may be contributing to the problem of tau being small, by a factor of 3, compared to the S82 quasars even after matching the depths. This PR assigns filter-dependent tau in the same manner as what we do for SF_inf.